### PR TITLE
Replace translationState function with array of models

### DIFF
--- a/BottomSheet.xcodeproj/project.pbxproj
+++ b/BottomSheet.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 		CF153A022382F88E001687C1 /* BottomSheet.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CF1539BD2382F20E001687C1 /* BottomSheet.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		CF153A062382F938001687C1 /* DemoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF1539E12382F3F6001687C1 /* DemoViewController.swift */; };
 		CF46A383238593AD00FFCB9F /* BottomSheetCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF46A3812385902100FFCB9F /* BottomSheetCalculator.swift */; };
+		DA1152522387EAF5002E2F40 /* BottomSheetModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA1152502387EACE002E2F40 /* BottomSheetModel.swift */; };
+		DA11525523880010002E2F40 /* BottomSheetModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA11525323880010002E2F40 /* BottomSheetModelTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -72,6 +74,8 @@
 		CF1539F42382F621001687C1 /* SpringAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpringAnimator.swift; sourceTree = "<group>"; };
 		CF1539F52382F621001687C1 /* BottomSheetView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BottomSheetView.swift; sourceTree = "<group>"; };
 		CF46A3812385902100FFCB9F /* BottomSheetCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetCalculator.swift; sourceTree = "<group>"; };
+		DA1152502387EACE002E2F40 /* BottomSheetModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetModel.swift; sourceTree = "<group>"; };
+		DA11525323880010002E2F40 /* BottomSheetModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetModelTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -127,6 +131,7 @@
 			children = (
 				CF1539C02382F20E001687C1 /* BottomSheet.h */,
 				CF1539C12382F20E001687C1 /* Info.plist */,
+				DA1152502387EACE002E2F40 /* BottomSheetModel.swift */,
 				CF46A3812385902100FFCB9F /* BottomSheetCalculator.swift */,
 				CF1539F12382F621001687C1 /* BottomSheetPresentationController.swift */,
 				CF1539F32382F621001687C1 /* BottomSheetTransitioningDelegate.swift */,
@@ -139,6 +144,7 @@
 		CF1539CA2382F20E001687C1 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				DA11525323880010002E2F40 /* BottomSheetModelTests.swift */,
 				CF1539CB2382F20E001687C1 /* BottomSheetCalculatorTests.swift */,
 				CF1539CD2382F20E001687C1 /* Info.plist */,
 			);
@@ -327,6 +333,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DA1152522387EAF5002E2F40 /* BottomSheetModel.swift in Sources */,
 				CF1539FB2382F62A001687C1 /* BottomSheetPresentationController.swift in Sources */,
 				CF46A383238593AD00FFCB9F /* BottomSheetCalculator.swift in Sources */,
 				CF1539FC2382F62A001687C1 /* BottomSheetTransitioningDelegate.swift in Sources */,
@@ -339,6 +346,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DA11525523880010002E2F40 /* BottomSheetModelTests.swift in Sources */,
 				CF1539CC2382F20E001687C1 /* BottomSheetCalculatorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/BottomSheet.xcodeproj/project.pbxproj
+++ b/BottomSheet.xcodeproj/project.pbxproj
@@ -21,7 +21,7 @@
 		CF153A022382F88E001687C1 /* BottomSheet.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CF1539BD2382F20E001687C1 /* BottomSheet.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		CF153A062382F938001687C1 /* DemoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF1539E12382F3F6001687C1 /* DemoViewController.swift */; };
 		CF46A383238593AD00FFCB9F /* BottomSheetCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF46A3812385902100FFCB9F /* BottomSheetCalculator.swift */; };
-		DA1152522387EAF5002E2F40 /* BottomSheetModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA1152502387EACE002E2F40 /* BottomSheetModel.swift */; };
+		DA0F4B00238BDB85002DE188 /* TranslationTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA0F4AFE238BDB7C002DE188 /* TranslationTarget.swift */; };
 		DA11525523880010002E2F40 /* BottomSheetModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA11525323880010002E2F40 /* BottomSheetModelTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -74,7 +74,7 @@
 		CF1539F42382F621001687C1 /* SpringAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpringAnimator.swift; sourceTree = "<group>"; };
 		CF1539F52382F621001687C1 /* BottomSheetView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BottomSheetView.swift; sourceTree = "<group>"; };
 		CF46A3812385902100FFCB9F /* BottomSheetCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetCalculator.swift; sourceTree = "<group>"; };
-		DA1152502387EACE002E2F40 /* BottomSheetModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetModel.swift; sourceTree = "<group>"; };
+		DA0F4AFE238BDB7C002DE188 /* TranslationTarget.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TranslationTarget.swift; sourceTree = "<group>"; };
 		DA11525323880010002E2F40 /* BottomSheetModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetModelTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -131,7 +131,7 @@
 			children = (
 				CF1539C02382F20E001687C1 /* BottomSheet.h */,
 				CF1539C12382F20E001687C1 /* Info.plist */,
-				DA1152502387EACE002E2F40 /* BottomSheetModel.swift */,
+				DA0F4AFE238BDB7C002DE188 /* TranslationTarget.swift */,
 				CF46A3812385902100FFCB9F /* BottomSheetCalculator.swift */,
 				CF1539F12382F621001687C1 /* BottomSheetPresentationController.swift */,
 				CF1539F32382F621001687C1 /* BottomSheetTransitioningDelegate.swift */,
@@ -333,10 +333,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DA1152522387EAF5002E2F40 /* BottomSheetModel.swift in Sources */,
 				CF1539FB2382F62A001687C1 /* BottomSheetPresentationController.swift in Sources */,
 				CF46A383238593AD00FFCB9F /* BottomSheetCalculator.swift in Sources */,
 				CF1539FC2382F62A001687C1 /* BottomSheetTransitioningDelegate.swift in Sources */,
+				DA0F4B00238BDB85002DE188 /* TranslationTarget.swift in Sources */,
 				CF1539FF2382F62A001687C1 /* SpringAnimator.swift in Sources */,
 				CF1539FD2382F62A001687C1 /* BottomSheetView.swift in Sources */,
 			);

--- a/Sources/BottomSheetCalculator.swift
+++ b/Sources/BottomSheetCalculator.swift
@@ -36,54 +36,58 @@ struct BottomSheetCalculator {
     ///   - targetOffsets: array containing the different target offsets a BottomSheetView can transition between
     ///   - currentTargetIndex: index of the current target offset of the BottomSheetView
     ///   - isDismissable: flag specifying whether the last two offsets should dismiss the BottomSheetView
-    static func createLayout(for targetOffsets: [CGFloat], at currentTargetIndex: Int, isDismissible: Bool) -> [BottomSheetModel] {
+    static func createTranslationTargets(
+        for targetOffsets: [CGFloat],
+        at currentTargetIndex: Int,
+        in superview: UIView,
+        isDismissible: Bool
+    ) -> [TranslationTarget] {
         guard !targetOffsets.isEmpty else { return [] }
 
         let minOffset = targetOffsets.last ?? 0
         let maxOffset = targetOffsets.first ?? 0
         let maxThreshold: CGFloat = 75
 
-        // [0, thresholds, 0]
-        // Add 0s to array to limit translation above and below edge offsets
-        let thresholds = [0] + targetOffsets.mapPar { (first, second) -> CGFloat in
+        // Thresholds is how long you need to translate from one translation target to another
+        // If the BottomSheetView is dismissible we want the user to translate a certain amount before transitioning to the dismiss translation target
+        // If not, make it stop at the smallest target height by setting the first threshold to zero.
+        let lowestThreshold = isDismissible ? min((abs(superview.frame.height - maxOffset) * 0.25), maxThreshold) : 0
+        // We add a zero threshold at the end to make the BottomSheetView stop at its biggest height.
+        let highestThreshold: CGFloat = 0
+        // Calculate all the offsets in between
+        let thresholds = [lowestThreshold] + targetOffsets.mapPar { (first, second) -> CGFloat in
             min((abs(second - first) * 0.25), maxThreshold)
-        } + [0]
-
-        guard thresholds.count == targetOffsets.count + 1 else {
-            return []
-        }
+        } + [highestThreshold]
 
         // Calculate lower bounds
         let lowerOffsets = targetOffsets[currentTargetIndex...]
         let lowerThresholds = thresholds[(currentTargetIndex + 1)...]
-        let lowerBounds = zip(lowerOffsets, lowerThresholds).map { (offset, threshold) -> CGFloat in
-            offset - threshold
-        }
+        let lowerBounds = zip(lowerOffsets, lowerThresholds).map(-)
 
         // Calculate upper bounds
         let upperOffsets = targetOffsets[...currentTargetIndex]
         let upperThresholds = thresholds[...currentTargetIndex]
-        let upperBounds = zip(upperOffsets, upperThresholds).map { (offset, threshold) -> CGFloat in
-            offset + threshold
-        }
+        let upperBounds = zip(upperOffsets, upperThresholds).map(+)
 
-        let bounds = upperBounds.dropFirst() + lowerBounds
-        var upperBound = upperBounds.first ?? 0
+        let bounds = upperBounds + lowerBounds
 
         // Model used to control offsets bigger than or equal to maxOffset
-        let bottomModel = LimitModel(
-            targetOffset: maxOffset,
+        let bottomModel = LimitTarget(
+            targetOffset: isDismissible ? superview.frame.height : maxOffset,
+            bound: bounds.first ?? maxOffset,
+            behavior: isDismissible ? .linear : .stop,
             isDismissible: isDismissible,
             compare: >=
         )
 
-        var models: [BottomSheetModel] = [bottomModel]
+        var upperBound = bounds.first ?? 0
+        var models: [TranslationTarget] = [bottomModel]
 
-        for (index, lowerBound) in bounds.enumerated() {
-            let model = RangeModel(
-                targetOffset: targetOffsets[index],
+        for (targetOffset, lowerBound) in zip(targetOffsets, bounds.dropFirst()) {
+            let model = RangeTarget(
+                targetOffset: targetOffset,
                 range: lowerBound ..< upperBound,
-                isDismissible: isDismissible && index == 0
+                isDismissible: false
             )
 
             models.append(model)
@@ -91,8 +95,10 @@ struct BottomSheetCalculator {
         }
 
         // Model used to control offsets smaller than  minOffset
-        let topModel = LimitModel(
+        let topModel = LimitTarget(
             targetOffset: minOffset,
+            bound: minOffset,
+            behavior: .rubberBand(radius: min(minOffset * 0.25, maxThreshold)),
             isDismissible: false,
             compare: <
         )

--- a/Sources/BottomSheetCalculator.swift
+++ b/Sources/BottomSheetCalculator.swift
@@ -30,68 +30,98 @@ struct BottomSheetCalculator {
         return max(superview.frame.height - makeTargetHeight(), handleHeight)
     }
 
-    /// Calculates bottom and top thresholds for the given target offsets.
+    /// Creates the layout of the BottomSheet based on the target offsets and the current target offset
+    ///
     /// - Parameters:
-    ///   - contentView: the content view of the bottom sheet
-    ///   - superview: the bottom sheet container view
-    ///   - height: preferred height for the content view
-    static func thresholds(for targetOffsets: [CGFloat], in superview: UIView) -> [CGFloat] {
+    ///   - targetOffsets: array containing the different target offsets a BottomSheet can transition between
+    ///   - currentTargetIndex: index of the current target offset of the BottomSheet
+    ///   - isDismissable: flag specifying whether the last two offsets should dismiss the BottomSheet
+    static func createLayout(for targetOffsets: [CGFloat], at currentTargetIndex: Int, isDismissible: Bool) -> [BottomSheetModel] {
         guard !targetOffsets.isEmpty else { return [] }
 
+        let minOffset = targetOffsets.last ?? 0
+        let maxOffset = targetOffsets.first ?? 0
         let maxThreshold: CGFloat = 75
-        let targetOffsets = [0] + targetOffsets + [superview.frame.height]
 
-        return zip(targetOffsets.dropFirst(), targetOffsets).map {
-            min(abs(($0 - $1) * 0.25), maxThreshold)
+        // [0, thresholds, 0]
+        // Add 0s to array to limit translation above and below edge offsets
+        let thresholds = [0] + targetOffsets.mapPar { (first, second) -> CGFloat in
+            min((abs(second - first) * 0.25), maxThreshold)
+        } + [0]
+
+        guard thresholds.count == targetOffsets.count + 1 else {
+            return []
         }
-    }
 
-    static func translationState(
-        from source: CGFloat,
-        to destination: CGFloat,
-        targetOffsets: [CGFloat],
-        thresholds: [CGFloat],
-        currentTargetOffsetIndex: Int
-    ) -> TranslationState? {
-        guard currentTargetOffsetIndex >= 0 && currentTargetOffsetIndex < targetOffsets.count else { return nil }
-        guard thresholds.count == targetOffsets.count + 1 else { return nil }
-
-        let currentTargetOffset = targetOffsets[currentTargetOffsetIndex]
-        let lowerBound = currentTargetOffset - thresholds[currentTargetOffsetIndex]
-        let upperBound = currentTargetOffset + thresholds[currentTargetOffsetIndex + 1]
-        let currentArea = lowerBound ... upperBound
-
-        if currentArea.contains(destination) {
-            // Within the area of the current target offset, allow dragging.
-            return TranslationState(nextOffset: destination, targetOffset: currentTargetOffset, isDismissible: false)
-        } else if destination < currentTargetOffset {
-            let targetOffset = targetOffsets.first(where: { $0 < destination })
-            // Above the area of the current target offset, allow dragging if the next target offset is found.
-            return TranslationState(
-                nextOffset: targetOffset == nil ? source : destination,
-                targetOffset: targetOffset ?? currentTargetOffset,
-                isDismissible: false
-            )
-        } else {
-            let targetOffset = targetOffsets.first(where: { $0 > destination })
-            // Below the area of the current target offset,
-            // allow dragging and set as dismissable if the next target offset is not found.
-            return TranslationState(
-                nextOffset: destination,
-                targetOffset: targetOffset ?? currentTargetOffset,
-                isDismissible: targetOffset == nil
-            )
+        // Calculate lower bounds
+        let lowerOffsets = targetOffsets[currentTargetIndex...]
+        let lowerThresholds = thresholds[(currentTargetIndex + 1)...]
+        let lowerBounds = zip(lowerOffsets, lowerThresholds).map { (offset, threshold) -> CGFloat in
+            offset - threshold
         }
+
+        // Calculate upper bounds
+        let upperOffsets = targetOffsets[...currentTargetIndex]
+        let upperThresholds = thresholds[...currentTargetIndex]
+        let upperBounds = zip(upperOffsets, upperThresholds).map { (offset, threshold) -> CGFloat in
+            offset + threshold
+        }
+
+        let bounds = upperBounds.dropFirst() + lowerBounds
+        var upperBound = upperBounds.first ?? 0
+
+        // Model used to control offsets bigger than or equal to maxOffset
+        let bottomModel = LimitModel(
+            targetOffset: maxOffset,
+            isDismissible: isDismissible,
+            compare: >=
+        )
+
+        var models: [BottomSheetModel] = [bottomModel]
+
+        for (index, lowerBound) in bounds.enumerated() {
+            let model = RangeModel(
+                targetOffset: targetOffsets[index],
+                range: lowerBound ..< upperBound,
+                isDismissible: isDismissible && index == 0
+            )
+
+            models.append(model)
+            upperBound = lowerBound
+        }
+
+        // Model used to control offsets smaller than  minOffset
+        let topModel = LimitModel(
+            targetOffset: minOffset,
+            isDismissible: false,
+            compare: <
+        )
+
+        models.append(topModel)
+
+        return models
     }
 }
 
 // MARK: - Helper types
 
-struct TranslationState {
-    /// The offset to be set for the current pan gesture translation.
-    let nextOffset: CGFloat
-    /// The offset to be set when the pan gesture ended, cancelled or failed.
-    let targetOffset: CGFloat
-    /// A flag indicating whether the view is ready to be dismissed.
-    let isDismissible: Bool
+private extension Sequence {
+
+    /// Iterate through array two elements at a time
+    ///
+    func mapPar<T>(_ transform: (Element, Element) -> T) -> [T] {
+        var iterator = makeIterator()
+        var transformed = [T]()
+
+        guard var first = iterator.next() else {
+            return []
+        }
+
+        while let second = iterator.next() {
+            transformed.append(transform(first, second))
+            first = second
+        }
+
+        return transformed
+    }
 }

--- a/Sources/BottomSheetCalculator.swift
+++ b/Sources/BottomSheetCalculator.swift
@@ -35,7 +35,8 @@ struct BottomSheetCalculator {
     /// - Parameters:
     ///   - targetOffsets: array containing the different target offsets a BottomSheetView can transition between
     ///   - currentTargetIndex: index of the current target offset of the BottomSheetView
-    ///   - isDismissable: flag specifying whether the last two offsets should dismiss the BottomSheetView
+    ///   - superview: the bottom sheet container view
+    ///   - isDismissable: flag specifying whether the last translation target should dismiss the BottomSheetView
     static func createTranslationTargets(
         for targetOffsets: [CGFloat],
         at currentTargetIndex: Int,
@@ -55,8 +56,8 @@ struct BottomSheetCalculator {
         // We add a zero threshold at the end to make the BottomSheetView stop at its biggest height.
         let highestThreshold: CGFloat = 0
         // Calculate all the offsets in between
-        let thresholds = [lowestThreshold] + targetOffsets.mapPar { (first, second) -> CGFloat in
-            min((abs(second - first) * 0.25), maxThreshold)
+        let thresholds = [lowestThreshold] + zip(targetOffsets.dropFirst(), targetOffsets).map {
+            min((abs($1 - $0) * 0.25), maxThreshold)
         } + [highestThreshold]
 
         // Calculate lower bounds
@@ -106,28 +107,5 @@ struct BottomSheetCalculator {
         models.append(topModel)
 
         return models
-    }
-}
-
-// MARK: - Helper types
-
-private extension Sequence {
-
-    /// Iterate through array two elements at a time
-    ///
-    func mapPar<T>(_ transform: (Element, Element) -> T) -> [T] {
-        var iterator = makeIterator()
-        var transformed = [T]()
-
-        guard var first = iterator.next() else {
-            return []
-        }
-
-        while let second = iterator.next() {
-            transformed.append(transform(first, second))
-            first = second
-        }
-
-        return transformed
     }
 }

--- a/Sources/BottomSheetCalculator.swift
+++ b/Sources/BottomSheetCalculator.swift
@@ -30,12 +30,12 @@ struct BottomSheetCalculator {
         return max(superview.frame.height - makeTargetHeight(), handleHeight)
     }
 
-    /// Creates the layout of the BottomSheet based on the target offsets and the current target offset
+    /// Creates the layout of the BottomSheetView based on the target offsets and the current target offset
     ///
     /// - Parameters:
-    ///   - targetOffsets: array containing the different target offsets a BottomSheet can transition between
-    ///   - currentTargetIndex: index of the current target offset of the BottomSheet
-    ///   - isDismissable: flag specifying whether the last two offsets should dismiss the BottomSheet
+    ///   - targetOffsets: array containing the different target offsets a BottomSheetView can transition between
+    ///   - currentTargetIndex: index of the current target offset of the BottomSheetView
+    ///   - isDismissable: flag specifying whether the last two offsets should dismiss the BottomSheetView
     static func createLayout(for targetOffsets: [CGFloat], at currentTargetIndex: Int, isDismissible: Bool) -> [BottomSheetModel] {
         guard !targetOffsets.isEmpty else { return [] }
 

--- a/Sources/BottomSheetModel.swift
+++ b/Sources/BottomSheetModel.swift
@@ -1,0 +1,79 @@
+//
+//  Copyright © 2019 FINN.no. All rights reserved.
+//
+
+import CoreGraphics
+
+/// Model defining a certain area of a BottomSheetView.
+///
+protocol BottomSheetModel {
+
+    /// An offset which a BottomSheetView can transition to
+    ///
+    var targetOffset: CGFloat { get }
+
+    /// Flag specifying whether a BottomSheetView should be dismissed.
+    /// This should only be used when presented by a presentation controller
+    ///
+    var isDismissible: Bool { get }
+
+    /// BottomSheetView will find the model which contains the current translation offset
+    /// and transition to its target offset when it's gesture ends.
+    ///
+    /// - Parameters:
+    ///   - offset: some offset. E.g. a pan gesture's translation, a table view's contentOffset.
+    ///
+    /// Return true if a BottomSheetView should transition to this target offset.
+    ///
+    func contains(offset: CGFloat) -> Bool
+
+    /// This method is called when a BottomSheetView's pan gesture changes.
+    ///
+    /// - Parameters:
+    ///   - offset: some offset. E.g. a pan gesture's translation, a table view's contentOffset.
+    ///
+    /// BottomSheetView calls this method to set the constant of it's constraint
+    /// Use this method to alter the panning movement of a BottomSheetView. E.g. make it bounce, or stick to a value.
+    ///
+    func nextOffset(for offset: CGFloat) -> CGFloat
+}
+
+/// RangeModel has an upper and a lower bound defining a range around the target offset
+///
+struct RangeModel: BottomSheetModel {
+    let targetOffset: CGFloat
+    let range: Range<CGFloat>
+    let isDismissible: Bool
+
+    func contains(offset: CGFloat) -> Bool {
+        range.contains(offset)
+    }
+
+    func nextOffset(for offset: CGFloat) -> CGFloat {
+        offset
+    }
+}
+
+/// LimitModel will compare the offset against it's target offset
+///
+/// A lower limit model will stop a BottomSheetView to translate below it's lowest target offset
+///
+///     let lowerLimit = LimitModel(
+///         targetOffset: offset,
+///         isDismissable: false,
+///         compare: <
+///     )
+///
+struct LimitModel: BottomSheetModel {
+    let targetOffset: CGFloat
+    let isDismissible: Bool
+    let compare: (CGFloat, CGFloat) -> Bool
+
+    func contains(offset: CGFloat) -> Bool {
+        compare(offset, targetOffset)
+    }
+
+    func nextOffset(for offset: CGFloat) -> CGFloat {
+        targetOffset
+    }
+}

--- a/Sources/BottomSheetPresentationController.swift
+++ b/Sources/BottomSheetPresentationController.swift
@@ -31,6 +31,7 @@ final class BottomSheetPresentationController: UIPresentationController {
         targetHeights: [CGFloat],
         startTargetIndex: Int
     ) {
+        // Add 0 height for dismiss target height
         self.targetHeights = [0] + targetHeights
         self.startTargetIndex = startTargetIndex + 1
         super.init(presentedViewController: presentedViewController, presenting: presenting)

--- a/Sources/BottomSheetPresentationController.swift
+++ b/Sources/BottomSheetPresentationController.swift
@@ -31,8 +31,8 @@ final class BottomSheetPresentationController: UIPresentationController {
         targetHeights: [CGFloat],
         startTargetIndex: Int
     ) {
-        self.targetHeights = targetHeights
-        self.startTargetIndex = startTargetIndex
+        self.targetHeights = [0] + targetHeights
+        self.startTargetIndex = startTargetIndex + 1
         super.init(presentedViewController: presentedViewController, presenting: presenting)
     }
 
@@ -40,7 +40,13 @@ final class BottomSheetPresentationController: UIPresentationController {
 
     override func presentationTransitionWillBegin() {
         guard let presentedView = presentedView else { return }
-        bottomSheetView = BottomSheetView(contentView: presentedView, targetHeights: targetHeights)
+
+        bottomSheetView = BottomSheetView(
+            contentView: presentedView,
+            targetHeights: targetHeights,
+            isDismissible: true
+        )
+
         bottomSheetView?.delegate = self
         bottomSheetView?.isDimViewHidden = false
     }

--- a/Sources/BottomSheetPresentationController.swift
+++ b/Sources/BottomSheetPresentationController.swift
@@ -31,9 +31,8 @@ final class BottomSheetPresentationController: UIPresentationController {
         targetHeights: [CGFloat],
         startTargetIndex: Int
     ) {
-        // Add 0 height for dismiss target height
-        self.targetHeights = [0] + targetHeights
-        self.startTargetIndex = startTargetIndex + 1
+        self.targetHeights = targetHeights
+        self.startTargetIndex = startTargetIndex
         super.init(presentedViewController: presentedViewController, presenting: presenting)
     }
 

--- a/Sources/BottomSheetView.swift
+++ b/Sources/BottomSheetView.swift
@@ -140,7 +140,13 @@ public final class BottomSheetView: UIView {
     /// Call this method e.g. when orientation change is detected.
     public func reset() {
         updateTargetOffsets()
-        transition(to: 0)
+
+        guard let superview = superview, let index = targetOffsets.firstIndex(where: { $0 < superview.frame.height }) else {
+            return
+        }
+
+        currentTargetOffsetIndex = index
+        transition(to: index)
     }
 
     /// Animates bottom sheet view to the given height.
@@ -207,7 +213,7 @@ public final class BottomSheetView: UIView {
     }
 
     private func updateDimViewAlpha(for offset: CGFloat) {
-        if let superview = superview, let mainOffset = targetOffsets.first(where: { $0 < super.frame.height }) {
+        if let superview = superview, let mainOffset = targetOffsets.first(where: { $0 < superview.frame.height }) {
             dimView.alpha = min(1, (superview.frame.height - offset) / (superview.frame.height - mainOffset))
         }
     }

--- a/Sources/BottomSheetView.swift
+++ b/Sources/BottomSheetView.swift
@@ -214,9 +214,8 @@ public final class BottomSheetView: UIView {
     }
 
     private func updateDimViewAlpha(for offset: CGFloat) {
-        if let superview = superview, let lowestHeight = targetHeights.first {
-            let highestOffset = BottomSheetCalculator.offset(for: contentView, in: superview, height: lowestHeight)
-            dimView.alpha = min(1, (superview.frame.height - offset) / (superview.frame.height - highestOffset))
+        if let superview = superview, let maxOffset = targetOffsets.max() {
+            dimView.alpha = min(1, (superview.frame.height - offset) / (superview.frame.height - maxOffset))
         }
     }
 

--- a/Sources/BottomSheetView.swift
+++ b/Sources/BottomSheetView.swift
@@ -202,14 +202,14 @@ public final class BottomSheetView: UIView {
 
     // MARK: - Animations
 
-    private func animate(to offset: CGFloat, with initialVelocity: CGPoint) {
+    private func animate(to offset: CGFloat, with initialVelocity: CGPoint = .zero) {
         if let index = targetOffsets.firstIndex(of: offset) {
             currentTargetOffsetIndex = index
         }
 
         springAnimator.fromPosition = CGPoint(x: 0, y: topConstraint.constant)
         springAnimator.toPosition = CGPoint(x: 0, y: offset)
-        springAnimator.initialVelocity = -initialVelocity
+        springAnimator.initialVelocity = initialVelocity
         springAnimator.startAnimation()
     }
 
@@ -241,7 +241,6 @@ public final class BottomSheetView: UIView {
 
         case .ended, .cancelled, .failed:
             initialOffset = nil
-
 
             if translationTarget.isDismissible {
                 delegate?.bottomSheetViewDidReachDismissArea(self)

--- a/Sources/TranslationTarget.swift
+++ b/Sources/TranslationTarget.swift
@@ -6,7 +6,7 @@ import CoreGraphics
 
 /// Model defining a certain area of a BottomSheetView.
 ///
-protocol BottomSheetModel {
+protocol TranslationTarget {
 
     /// An offset which a BottomSheetView can transition to
     ///
@@ -18,10 +18,10 @@ protocol BottomSheetModel {
     var isDismissible: Bool { get }
 
     /// BottomSheetView will find the model which contains the current translation offset
-    /// and transition to its target offset when it's gesture ends.
+    /// and transition to its target offset when its gesture ends.
     ///
     /// - Parameters:
-    ///   - offset: some offset. E.g. a pan gesture's translation, a table view's contentOffset.
+    ///   - offset: some offset. E.g. a pan gestures translation, a table view's contentOffset.
     ///
     /// Return true if a BottomSheetView should transition to this target offset.
     ///
@@ -30,17 +30,24 @@ protocol BottomSheetModel {
     /// This method is called when a BottomSheetView's pan gesture changes.
     ///
     /// - Parameters:
-    ///   - offset: some offset. E.g. a pan gesture's translation, a table view's contentOffset.
+    ///   - offset: some offset. E.g. a pan gesture's translation, a table views contentOffset.
     ///
-    /// BottomSheetView calls this method to set the constant of it's constraint
+    /// BottomSheetView calls this method to set the constant of its constraint
     /// Use this method to alter the panning movement of a BottomSheetView. E.g. make it bounce, or stick to a value.
     ///
     func nextOffset(for offset: CGFloat) -> CGFloat
 }
 
-/// RangeModel has an upper and a lower bound defining a range around the target offset
+/// Defines the behavior of the translation
+enum TranslationBehavior {
+    case linear
+    case rubberBand(radius: CGFloat)
+    case stop
+}
+
+/// RangeTarget has an upper and a lower bound defining a range around its target offset
 ///
-struct RangeModel: BottomSheetModel {
+struct RangeTarget: TranslationTarget {
     let targetOffset: CGFloat
     let range: Range<CGFloat>
     let isDismissible: Bool
@@ -54,26 +61,45 @@ struct RangeModel: BottomSheetModel {
     }
 }
 
-/// LimitModel will compare the offset against it's target offset
+/// LimitTarget will compare the offset against its bound
 ///
-/// A lower limit model will stop a BottomSheetView to translate below it's lowest target offset
+/// A lower limit model will stop a BottomSheetView translating below its lowest target offset
 ///
 ///     let lowerLimit = LimitModel(
 ///         targetOffset: offset,
+///         bound: offset,
+///         behavior: .stop,
 ///         isDismissable: false,
 ///         compare: <
 ///     )
 ///
-struct LimitModel: BottomSheetModel {
+struct LimitTarget: TranslationTarget {
     let targetOffset: CGFloat
+    let bound: CGFloat
+    let behavior: TranslationBehavior
     let isDismissible: Bool
     let compare: (CGFloat, CGFloat) -> Bool
 
     func contains(offset: CGFloat) -> Bool {
-        compare(offset, targetOffset)
+        compare(offset, bound)
     }
 
     func nextOffset(for offset: CGFloat) -> CGFloat {
-        targetOffset
+        switch behavior {
+        case .linear:
+            return offset
+        case .rubberBand(let radius):
+            let distance = offset - bound
+            let newOffset = radius * (1 - exp(-abs(distance) / radius))
+
+            if distance < 0 {
+                return bound - newOffset
+            } else {
+                return bound + newOffset
+            }
+
+        case .stop:
+            return bound
+        }
     }
 }

--- a/Tests/BottomSheetCalculatorTests.swift
+++ b/Tests/BottomSheetCalculatorTests.swift
@@ -27,28 +27,28 @@ final class BottomSheetCalculatorTests: XCTestCase {
     }
 
     func testLayoutWithEmptyOffsets() {
-        XCTAssertTrue(BottomSheetCalculator.createLayout(for: [], at: 0, isDismissible: false).isEmpty)
+        XCTAssertTrue(BottomSheetCalculator.createTranslationTargets(for: [], at: 0, in: superview, isDismissible: false).isEmpty)
     }
 
     func testLayoutModelsWithSingleOffset() {
-        let models = BottomSheetCalculator.createLayout(for: [500], at: 0, isDismissible: false)
+        let models = BottomSheetCalculator.createTranslationTargets(for: [500], at: 0, in: superview, isDismissible: false)
 
         XCTAssertEqual(models.count, 3)
-        XCTAssertTrue(models[0] is LimitModel)
-        XCTAssertTrue(models[1] is RangeModel)
-        XCTAssertTrue(models[2] is LimitModel)
+        XCTAssertTrue(models[0] is LimitTarget)
+        XCTAssertTrue(models[1] is RangeTarget)
+        XCTAssertTrue(models[2] is LimitTarget)
     }
 
     func testLayoutModelsWithMultipleOffsets() {
-        let models = BottomSheetCalculator.createLayout(for: [700, 300, 100], at: 0, isDismissible: false)
+        let models = BottomSheetCalculator.createTranslationTargets(for: [700, 300, 100], at: 0, in: superview, isDismissible: false)
 
         XCTAssertEqual(models.count, 5)
-        XCTAssertTrue(models.first is LimitModel)
-        XCTAssertTrue(models.last is LimitModel)
+        XCTAssertTrue(models.first is LimitTarget)
+        XCTAssertTrue(models.last is LimitTarget)
     }
 
     func testLayoutModelsWhenContainingOffset() {
-        let models = BottomSheetCalculator.createLayout(for: [700, 300, 100], at: 0, isDismissible: false)
+        let models = BottomSheetCalculator.createTranslationTargets(for: [700, 300, 100], at: 0, in: superview, isDismissible: false)
 
         XCTAssertTrue(models[0].contains(offset: 800))
         XCTAssertTrue(models[1].contains(offset: 690))
@@ -59,7 +59,7 @@ final class BottomSheetCalculatorTests: XCTestCase {
     }
 
     func testLayoutModelsWhenNotContainingOffset() {
-        let models = BottomSheetCalculator.createLayout(for: [700, 300, 100], at: 0, isDismissible: false)
+        let models = BottomSheetCalculator.createTranslationTargets(for: [700, 300, 100], at: 0, in: superview, isDismissible: false)
         XCTAssertFalse(models[0].contains(offset: 600))
         XCTAssertFalse(models[1].contains(offset: 300))
         XCTAssertFalse(models[2].contains(offset: 100))
@@ -68,23 +68,23 @@ final class BottomSheetCalculatorTests: XCTestCase {
     }
 
     func testLayoutThresholds() {
-        let models = BottomSheetCalculator.createLayout(for: [700, 600, 400], at: 1, isDismissible: false)
+        let models = BottomSheetCalculator.createTranslationTargets(for: [700, 600, 400], at: 1, in: superview, isDismissible: false)
 
-        guard let firstModel = models[1] as? RangeModel else {
+        guard let firstModel = models[1] as? RangeTarget else {
             return
         }
 
         XCTAssertEqual(firstModel.range.lowerBound, 600 + 25)
         XCTAssertEqual(firstModel.range.upperBound, 700 - 0)
 
-        guard let secondModel = models[2] as? RangeModel else {
+        guard let secondModel = models[2] as? RangeTarget else {
             return
         }
 
         XCTAssertEqual(secondModel.range.lowerBound, 600 - 50)
         XCTAssertEqual(secondModel.range.upperBound, 600 + 25)
 
-        guard let thirdModel = models[3] as? RangeModel else {
+        guard let thirdModel = models[3] as? RangeTarget else {
             return
         }
 

--- a/Tests/BottomSheetModelTests.swift
+++ b/Tests/BottomSheetModelTests.swift
@@ -7,7 +7,7 @@ import XCTest
 
 final class BottomSheetModelTests: XCTestCase {
 
-    func testRangeModel() {
+    func testRangeTarget() {
         let rangeModel = RangeTarget(
             targetOffset: 500,
             range: 300 ..< 600,
@@ -20,11 +20,13 @@ final class BottomSheetModelTests: XCTestCase {
         XCTAssertEqual(rangeModel.nextOffset(for: 400), 400)
     }
 
-    func testLowerLimitModel() {
+    func testLowerLimitTargetWithStopBehaviour() {
         let targetOffset: CGFloat = 200
 
         let lowerLimitModel = LimitTarget(
             targetOffset: targetOffset,
+            bound: targetOffset,
+            behavior: .stop,
             isDismissible: false,
             compare: <
         )
@@ -34,17 +36,40 @@ final class BottomSheetModelTests: XCTestCase {
         XCTAssertEqual(lowerLimitModel.nextOffset(for: 100), targetOffset)
     }
 
-    func testUpperLimitModel() {
+    func testLowerLimitTargetWithRubberBandBehaviour() {
+        let bound: CGFloat = 300
+        let radius: CGFloat = 75
+
+        let lowerLimitModel = LimitTarget(
+            targetOffset: bound,
+            bound: bound,
+            behavior: .rubberBand(radius: radius),
+            isDismissible: false,
+            compare: <
+        )
+
+        XCTAssertTrue(lowerLimitModel.contains(offset: 200))
+        XCTAssertFalse(lowerLimitModel.contains(offset: 500))
+
+        let offset: CGFloat = 200
+        let distance = offset - bound
+        let nextOffset = radius * (1 - exp(-abs(distance) / radius))
+        XCTAssertEqual(lowerLimitModel.nextOffset(for: offset), bound - nextOffset)
+    }
+
+    func testUpperLimitTargetWithLinearBehaviour() {
         let targetOffset: CGFloat = 700
 
         let upperLimitModel = LimitTarget(
             targetOffset: targetOffset,
+            bound: 700,
+            behavior: .linear,
             isDismissible: false,
             compare: >=
         )
 
         XCTAssertFalse(upperLimitModel.contains(offset: 300))
         XCTAssertTrue(upperLimitModel.contains(offset: 800))
-        XCTAssertEqual(upperLimitModel.nextOffset(for: 800), targetOffset)
+        XCTAssertEqual(upperLimitModel.nextOffset(for: 800), 800)
     }
 }

--- a/Tests/BottomSheetModelTests.swift
+++ b/Tests/BottomSheetModelTests.swift
@@ -8,7 +8,7 @@ import XCTest
 final class BottomSheetModelTests: XCTestCase {
 
     func testRangeModel() {
-        let rangeModel = RangeModel(
+        let rangeModel = RangeTarget(
             targetOffset: 500,
             range: 300 ..< 600,
             isDismissible: false
@@ -23,7 +23,7 @@ final class BottomSheetModelTests: XCTestCase {
     func testLowerLimitModel() {
         let targetOffset: CGFloat = 200
 
-        let lowerLimitModel = LimitModel(
+        let lowerLimitModel = LimitTarget(
             targetOffset: targetOffset,
             isDismissible: false,
             compare: <
@@ -37,7 +37,7 @@ final class BottomSheetModelTests: XCTestCase {
     func testUpperLimitModel() {
         let targetOffset: CGFloat = 700
 
-        let upperLimitModel = LimitModel(
+        let upperLimitModel = LimitTarget(
             targetOffset: targetOffset,
             isDismissible: false,
             compare: >=

--- a/Tests/BottomSheetModelTests.swift
+++ b/Tests/BottomSheetModelTests.swift
@@ -1,0 +1,50 @@
+//
+//  Copyright © 2019 FINN.no. All rights reserved.
+//
+
+import XCTest
+@testable import BottomSheet
+
+final class BottomSheetModelTests: XCTestCase {
+
+    func testRangeModel() {
+        let rangeModel = RangeModel(
+            targetOffset: 500,
+            range: 300 ..< 600,
+            isDismissible: false
+        )
+
+        XCTAssertFalse(rangeModel.contains(offset: 200))
+        XCTAssertTrue(rangeModel.contains(offset: 400))
+        XCTAssertFalse(rangeModel.contains(offset: 700))
+        XCTAssertEqual(rangeModel.nextOffset(for: 400), 400)
+    }
+
+    func testLowerLimitModel() {
+        let targetOffset: CGFloat = 200
+
+        let lowerLimitModel = LimitModel(
+            targetOffset: targetOffset,
+            isDismissible: false,
+            compare: <
+        )
+
+        XCTAssertTrue(lowerLimitModel.contains(offset: 100))
+        XCTAssertFalse(lowerLimitModel.contains(offset: 300))
+        XCTAssertEqual(lowerLimitModel.nextOffset(for: 100), targetOffset)
+    }
+
+    func testUpperLimitModel() {
+        let targetOffset: CGFloat = 700
+
+        let upperLimitModel = LimitModel(
+            targetOffset: targetOffset,
+            isDismissible: false,
+            compare: >=
+        )
+
+        XCTAssertFalse(upperLimitModel.contains(offset: 300))
+        XCTAssertTrue(upperLimitModel.contains(offset: 800))
+        XCTAssertEqual(upperLimitModel.nextOffset(for: 800), targetOffset)
+    }
+}


### PR DESCRIPTION
# Why?

The method to create translation states was quite complex and would probably become more complex in the future. This made the BottomSheetView a bit unstable.

# What?

- Creates `TranslationTarget`s from an array of target offsets and the current target offset.
- Finds the `TranslationTarget` which contains the translation offset and animate to it's target offset on gesture ended
- Adds`isDismissible` flag when `BottomSheetView` is presented with `BottomSheetPresentationController`. This is to define the the behaviour of the `BottomSheetView` at its smallest height. 