### PR TITLE
Make sure we can present a bottom sheet without animation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout
-      - run: xcodebuild -project BottomSheet.xcodeproj -scheme "Demo" -sdk iphonesimulator -destination 'platform=iOS Simulator,OS=13.3,name=iPhone 11 Pro' build test | xcpretty
+      - run: xcodebuild -project BottomSheet.xcodeproj -scheme "Demo" -sdk iphonesimulator -destination 'platform=iOS Simulator,OS=13.2.2,name=iPhone 11 Pro' build test | xcpretty
 
   swiftlint:
     docker:

--- a/Sources/BottomSheetCalculator.swift
+++ b/Sources/BottomSheetCalculator.swift
@@ -13,21 +13,26 @@ struct BottomSheetCalculator {
     ///   - height: preferred height for the content view
     static func offset(for contentView: UIView, in superview: UIView, height: CGFloat) -> CGFloat {
         let handleHeight: CGFloat = 20
+        var contentHeight = targetHeight(for: contentView, in: superview, height: height)
 
-        func makeTargetHeight() -> CGFloat {
-            if height == .bottomSheetAutomatic {
-                let size = contentView.systemLayoutSizeFitting(
-                    superview.frame.size,
-                    withHorizontalFittingPriority: .required,
-                    verticalFittingPriority: .fittingSizeLevel
-                )
-                return size.height + handleHeight
-            } else {
-                return height
-            }
+        if height == .bottomSheetAutomatic {
+            contentHeight += handleHeight
         }
 
-        return max(superview.frame.height - makeTargetHeight(), handleHeight)
+        return max(superview.frame.height - contentHeight, handleHeight)
+    }
+
+    static func targetHeight(for contentView: UIView, in superview: UIView, height: CGFloat) -> CGFloat {
+        if height == .bottomSheetAutomatic {
+            let size = contentView.systemLayoutSizeFitting(
+                superview.frame.size,
+                withHorizontalFittingPriority: .required,
+                verticalFittingPriority: .fittingSizeLevel
+            )
+            return size.height
+        } else {
+            return height
+        }
     }
 
     /// Creates the translation targets of a BottomSheetView based on an array of target offsets and the current target offset

--- a/Sources/BottomSheetCalculator.swift
+++ b/Sources/BottomSheetCalculator.swift
@@ -13,16 +13,16 @@ struct BottomSheetCalculator {
     ///   - height: preferred height for the content view
     static func offset(for contentView: UIView, in superview: UIView, height: CGFloat) -> CGFloat {
         let handleHeight: CGFloat = 20
-        var contentHeight = targetHeight(for: contentView, in: superview, height: height)
+        var targetHeight = contentHeight(for: contentView, in: superview, height: height)
 
         if height == .bottomSheetAutomatic {
-            contentHeight += handleHeight
+            targetHeight += handleHeight
         }
 
-        return max(superview.frame.height - contentHeight, handleHeight)
+        return max(superview.frame.height - targetHeight, handleHeight)
     }
 
-    static func targetHeight(for contentView: UIView, in superview: UIView, height: CGFloat) -> CGFloat {
+    static func contentHeight(for contentView: UIView, in superview: UIView, height: CGFloat) -> CGFloat {
         if height == .bottomSheetAutomatic {
             let size = contentView.systemLayoutSizeFitting(
                 superview.frame.size,

--- a/Sources/BottomSheetPresentationController.swift
+++ b/Sources/BottomSheetPresentationController.swift
@@ -60,7 +60,7 @@ final class BottomSheetPresentationController: UIPresentationController {
         guard let presentedView = presentedView else { return .zero }
         guard let containerView = containerView else { return .zero }
 
-        let contentHeight = BottomSheetCalculator.targetHeight(
+        let contentHeight = BottomSheetCalculator.contentHeight(
             for: presentedView,
             in: containerView,
             height: targetHeights[startTargetIndex]

--- a/Sources/BottomSheetPresentationController.swift
+++ b/Sources/BottomSheetPresentationController.swift
@@ -60,24 +60,15 @@ final class BottomSheetPresentationController: UIPresentationController {
         guard let presentedView = presentedView else { return .zero }
         guard let containerView = containerView else { return .zero }
 
-        let offset = BottomSheetCalculator.offset(
+        let contentHeight = BottomSheetCalculator.targetHeight(
             for: presentedView,
             in: containerView,
             height: targetHeights[startTargetIndex]
         )
 
-        let handleHeight: CGFloat = 20
-        let expectedHeight: CGFloat
-
-        if targetHeights[startTargetIndex] == .bottomSheetAutomatic {
-            expectedHeight = containerView.frame.height - offset - handleHeight
-        } else {
-            expectedHeight = containerView.frame.height - offset
-        }
-
         let size = CGSize(
             width: containerView.frame.width,
-            height: expectedHeight
+            height: contentHeight
         )
 
         return CGRect(

--- a/Sources/BottomSheetPresentationController.swift
+++ b/Sources/BottomSheetPresentationController.swift
@@ -15,7 +15,7 @@ final class BottomSheetPresentationController: UIPresentationController {
 
     // MARK: - Internal properties
 
-    var transitionState: TransitionState = .presenting
+    var transitionState: TransitionState?
 
     // MARK: - Private properties
 
@@ -39,6 +39,54 @@ final class BottomSheetPresentationController: UIPresentationController {
     // MARK: - Transition life cycle
 
     override func presentationTransitionWillBegin() {
+        guard transitionState == .presenting else { return }
+        createBottomSheetView()
+    }
+
+    override func presentationTransitionDidEnd(_ completed: Bool) {
+        guard transitionState == nil else { return }
+        guard let containerView = containerView else { return }
+
+        createBottomSheetView()
+
+        bottomSheetView?.present(
+            in: containerView,
+            targetIndex: startTargetIndex,
+            animated: false
+        )
+    }
+
+    override var frameOfPresentedViewInContainerView: CGRect {
+        guard let presentedView = presentedView else { return .zero }
+        guard let containerView = containerView else { return .zero }
+
+        let offset = BottomSheetCalculator.offset(
+            for: presentedView,
+            in: containerView,
+            height: targetHeights[startTargetIndex]
+        )
+
+        let handleHeight: CGFloat = 20
+        let expectedHeight: CGFloat
+
+        if targetHeights[startTargetIndex] == .bottomSheetAutomatic {
+            expectedHeight = containerView.frame.height - offset - handleHeight
+        } else {
+            expectedHeight = containerView.frame.height - offset
+        }
+
+        let size = CGSize(
+            width: containerView.frame.width,
+            height: expectedHeight
+        )
+
+        return CGRect(
+            origin: .zero,
+            size: size
+        )
+    }
+
+    private func createBottomSheetView() {
         guard let presentedView = presentedView else { return }
 
         bottomSheetView = BottomSheetView(
@@ -78,6 +126,9 @@ extension BottomSheetPresentationController: UIViewControllerAnimatedTransitioni
             )
         case .dismissing:
             bottomSheetView?.dismiss(completion: completion)
+
+        case .none:
+            return
         }
     }
 }

--- a/Sources/BottomSheetView.swift
+++ b/Sources/BottomSheetView.swift
@@ -97,16 +97,18 @@ public final class BottomSheetView: UIView {
         translatesAutoresizingMaskIntoConstraints = false
         dimView.frame = superview.bounds
 
-        let startConstant: CGFloat
+        let startOffset = BottomSheetCalculator.offset(
+            for: contentView,
+            in: superview,
+            height: targetHeights[targetIndex]
+        )
 
         if animated {
-            startConstant = superview.frame.height
+            topConstraint = topAnchor.constraint(equalTo: superview.topAnchor, constant: superview.frame.height)
         } else {
             dimView.alpha = 1.0
-            startConstant = BottomSheetCalculator.offset(for: contentView, in: superview, height: targetHeights[targetIndex])
+            topConstraint = topAnchor.constraint(equalTo: superview.topAnchor, constant: startOffset)
         }
-
-        topConstraint = topAnchor.constraint(equalTo: superview.topAnchor, constant: startConstant)
 
         springAnimator.addAnimation { [weak self] position in
             self?.topConstraint.constant = position.y
@@ -126,10 +128,7 @@ public final class BottomSheetView: UIView {
         addGestureRecognizer(panGesture)
 
         updateTargetOffsets()
-
-        let offset = BottomSheetCalculator.offset(for: contentView, in: superview, height: targetHeights[targetIndex])
-        currentTargetOffsetIndex = targetOffsets.firstIndex(of: offset) ?? 0
-
+        currentTargetOffsetIndex = targetOffsets.firstIndex(of: startOffset) ?? 0
         createTranslationTargets()
         transition(to: targetIndex)
     }

--- a/Sources/BottomSheetView.swift
+++ b/Sources/BottomSheetView.swift
@@ -88,7 +88,7 @@ public final class BottomSheetView: UIView {
     /// - Parameters:
     ///   - view: the container for the bottom sheet view
     ///   - completion: a closure to be executed when the animation ends
-    public func present(in superview: UIView, targetIndex: Int = 0, completion: ((Bool) -> Void)? = nil) {
+    public func present(in superview: UIView, targetIndex: Int = 0, animated: Bool = true, completion: ((Bool) -> Void)? = nil) {
         guard self.superview != superview else { return }
 
         superview.addSubview(dimView)
@@ -96,7 +96,17 @@ public final class BottomSheetView: UIView {
 
         translatesAutoresizingMaskIntoConstraints = false
         dimView.frame = superview.bounds
-        topConstraint = topAnchor.constraint(equalTo: superview.topAnchor, constant: superview.frame.height)
+
+        let offset: CGFloat
+
+        if animated {
+            offset = superview.frame.height
+        } else {
+            dimView.alpha = 1.0
+            offset = BottomSheetCalculator.offset(for: contentView, in: superview, height: targetHeights[targetIndex])
+        }
+
+        topConstraint = topAnchor.constraint(equalTo: superview.topAnchor, constant: offset)
 
         springAnimator.addAnimation { [weak self] position in
             self?.topConstraint.constant = position.y
@@ -115,7 +125,6 @@ public final class BottomSheetView: UIView {
         superview.layoutIfNeeded()
         addGestureRecognizer(panGesture)
 
-        currentTargetOffsetIndex = targetIndex
         updateTargetOffsets()
         transition(to: targetIndex)
     }

--- a/Sources/BottomSheetView.swift
+++ b/Sources/BottomSheetView.swift
@@ -128,9 +128,8 @@ public final class BottomSheetView: UIView {
         addGestureRecognizer(panGesture)
 
         updateTargetOffsets()
-        currentTargetOffsetIndex = targetOffsets.firstIndex(of: startOffset) ?? 0
-        createTranslationTargets()
         transition(to: targetIndex)
+        createTranslationTargets()
     }
 
     /// Animates bottom sheet view out of the screen bounds and removes it from the superview on completion.

--- a/Sources/BottomSheetView.swift
+++ b/Sources/BottomSheetView.swift
@@ -97,16 +97,16 @@ public final class BottomSheetView: UIView {
         translatesAutoresizingMaskIntoConstraints = false
         dimView.frame = superview.bounds
 
-        let offset: CGFloat
+        let startConstant: CGFloat
 
         if animated {
-            offset = superview.frame.height
+            startConstant = superview.frame.height
         } else {
             dimView.alpha = 1.0
-            offset = BottomSheetCalculator.offset(for: contentView, in: superview, height: targetHeights[targetIndex])
+            startConstant = BottomSheetCalculator.offset(for: contentView, in: superview, height: targetHeights[targetIndex])
         }
 
-        topConstraint = topAnchor.constraint(equalTo: superview.topAnchor, constant: offset)
+        topConstraint = topAnchor.constraint(equalTo: superview.topAnchor, constant: startConstant)
 
         springAnimator.addAnimation { [weak self] position in
             self?.topConstraint.constant = position.y
@@ -126,6 +126,11 @@ public final class BottomSheetView: UIView {
         addGestureRecognizer(panGesture)
 
         updateTargetOffsets()
+
+        let offset = BottomSheetCalculator.offset(for: contentView, in: superview, height: targetHeights[targetIndex])
+        currentTargetOffsetIndex = targetOffsets.firstIndex(of: offset) ?? 0
+
+        createTranslationTargets()
         transition(to: targetIndex)
     }
 
@@ -150,6 +155,7 @@ public final class BottomSheetView: UIView {
     /// Call this method e.g. when orientation change is detected.
     public func reset() {
         updateTargetOffsets()
+        createTranslationTargets()
         animate(to: targetOffsets[currentTargetOffsetIndex])
     }
 
@@ -265,8 +271,6 @@ public final class BottomSheetView: UIView {
         targetOffsets = targetHeights.map {
             BottomSheetCalculator.offset(for: contentView, in: superview, height: $0)
         }.sorted(by: >)
-
-        createTranslationTargets()
     }
 
     private func createTranslationTargets() {


### PR DESCRIPTION
# Why?

`present(bottomSheet, animated: false)` was broken. This PR fixes the issues with presenting a bottom sheet without animating.

# What?

- Adds `animated` argument to `present` method.
- Makes `transitionState` optional and is `nil` when not animating.
- Implement `frameOfPresentedViewInContainerView` to fix auto-layout conflict with `UIView-Encapsulated-Layout-Height`
- Create and present `BottomSheetView` in `presentationTransitionDidEnd` when not animating.