### PR TITLE
Spring animator should start animating with initial velocity

### DIFF
--- a/Sources/BottomSheetPresentationController.swift
+++ b/Sources/BottomSheetPresentationController.swift
@@ -21,6 +21,7 @@ final class BottomSheetPresentationController: UIPresentationController {
 
     private let targetHeights: [CGFloat]
     private let startTargetIndex: Int
+    private var dismissVelocity: CGPoint = .zero
     private var bottomSheetView: BottomSheetView?
 
     // MARK: - Init
@@ -116,7 +117,10 @@ extension BottomSheetPresentationController: UIViewControllerAnimatedTransitioni
                 completion: completion
             )
         case .dismissing:
-            bottomSheetView?.dismiss(completion: completion)
+            bottomSheetView?.dismiss(
+                velocity: dismissVelocity,
+                completion: completion
+            )
 
         case .none:
             return
@@ -139,7 +143,8 @@ extension BottomSheetPresentationController: BottomSheetViewDelegate {
         presentedViewController.dismiss(animated: true)
     }
 
-    func bottomSheetViewDidReachDismissArea(_ view: BottomSheetView) {
+    func bottomSheetViewDidReachDismissArea(_ view: BottomSheetView, with velocity: CGPoint) {
+        dismissVelocity = velocity
         presentedViewController.dismiss(animated: true)
     }
 }

--- a/Sources/SpringAnimator.swift
+++ b/Sources/SpringAnimator.swift
@@ -25,7 +25,7 @@ class SpringAnimator: NSObject {
 
     var initialVelocity: CGPoint = .zero {
         didSet {
-            velocity = initialVelocity
+            velocity = -initialVelocity
         }
     }
 

--- a/Sources/TranslationTarget.swift
+++ b/Sources/TranslationTarget.swift
@@ -9,33 +9,40 @@ import CoreGraphics
 protocol TranslationTarget {
 
     /// An offset which a BottomSheetView can transition to
-    ///
     var targetOffset: CGFloat { get }
 
     /// Flag specifying whether a BottomSheetView should be dismissed.
     /// This should only be used when presented by a presentation controller
-    ///
     var isDismissible: Bool { get }
 
     /// BottomSheetView will find the model which contains the current translation offset
     /// and transition to its target offset when its gesture ends.
     ///
     /// - Parameters:
-    ///   - offset: some offset. E.g. a pan gestures translation, a table view's contentOffset.
+    ///   - offset: some offset. E.g. a pan gestures translation, a table views contentOffset.
     ///
-    /// Return true if a BottomSheetView should transition to this target offset.
-    ///
+    /// - Returns: true if a BottomSheetView should transition to this target offset.
     func contains(offset: CGFloat) -> Bool
 
-    /// This method is called when a BottomSheetView's pan gesture changes.
+    /// This method is called when a BottomSheetViews pan gesture changes.
+    /// BottomSheetView calls this method to set the constant of its constraint
+    /// Use this method to alter the panning movement of a BottomSheetView. E.g. give it a rubber band effect
+    /// or make it stop at a certain offset
     ///
     /// - Parameters:
-    ///   - offset: some offset. E.g. a pan gesture's translation, a table views contentOffset.
-    ///
-    /// BottomSheetView calls this method to set the constant of its constraint
-    /// Use this method to alter the panning movement of a BottomSheetView. E.g. make it bounce, or stick to a value.
-    ///
+    ///   - offset: some offset. E.g. a pan gestures translation, a table views contentOffset.
     func nextOffset(for offset: CGFloat) -> CGFloat
+
+    /// This method is called when a BottomSheetViews pan gesture ends.
+    /// Use this method together with nextOffset(for:) to make a nice transition
+    /// between panning and animation.
+    ///
+    /// - Parameters:
+    ///   - velocity: the velocity of a pan gesture
+    ///   - offset: some offset. E.g. a pan gestures translation, a table views contentOffset.
+    ///
+    /// - Returns: The initial velocity of the spring animator.
+    func translateVelocity(_ velocity: CGPoint, for offset: CGFloat) -> CGPoint
 }
 
 /// Defines the behavior of the translation
@@ -46,7 +53,6 @@ enum TranslationBehavior {
 }
 
 /// RangeTarget has an upper and a lower bound defining a range around its target offset
-///
 struct RangeTarget: TranslationTarget {
     let targetOffset: CGFloat
     let range: Range<CGFloat>
@@ -58,6 +64,10 @@ struct RangeTarget: TranslationTarget {
 
     func nextOffset(for offset: CGFloat) -> CGFloat {
         offset
+    }
+
+    func translateVelocity(_ velocity: CGPoint, for offset: CGFloat) -> CGPoint {
+        velocity
     }
 }
 
@@ -100,6 +110,23 @@ struct LimitTarget: TranslationTarget {
 
         case .stop:
             return bound
+        }
+    }
+
+    func translateVelocity(_ velocity: CGPoint, for offset: CGFloat) -> CGPoint {
+        switch behavior {
+        case .linear:
+            return velocity
+        case .rubberBand(let radius):
+            let distance = offset - bound
+            let constant = exp(-abs(distance) / radius)
+
+            return CGPoint(
+                x: velocity.x * constant,
+                y: velocity.y * constant
+            )
+        case .stop:
+            return .zero
         }
     }
 }


### PR DESCRIPTION
# Why?

At the moment the spring animator will always start animating with an initial velocity of zero. The velocity should be the velocity of the pan gesture recogniser then it ends.

# What?

- Adds `dismissVelocity` to `BottomSheetPresentationController` to set the initial velocity of the dismiss animation.
- `BottomSheetView` asks the `translationTarget` for the initial velocity. 
- Adds `translateVelocity(_, for:)` method to `TranslationTarget` in order to sync the initial velocity with `nextOffset(for:)`. The initial velocity should be altered if behaviour is rubber band or stop.