### PR TITLE
Fix interactive presentation transition

### DIFF
--- a/Sources/BottomSheetPresentationController.swift
+++ b/Sources/BottomSheetPresentationController.swift
@@ -144,14 +144,14 @@ extension BottomSheetPresentationController: UIViewControllerInteractiveTransiti
 
 extension BottomSheetPresentationController: BottomSheetViewDelegate {
     func bottomSheetViewDidTapDimView(_ view: BottomSheetView) {
-        dismissIfNeeded(with: .zero)
+        dismiss(with: .zero)
     }
 
     func bottomSheetViewDidReachDismissArea(_ view: BottomSheetView, with velocity: CGPoint) {
-        dismissIfNeeded(with: velocity)
+        dismiss(with: velocity)
     }
 
-    private func dismissIfNeeded(with velocity: CGPoint) {
+    private func dismiss(with velocity: CGPoint) {
         switch transitionState {
         case .presenting:
             bottomSheetView?.dismiss(velocity: velocity, completion: { _ in


### PR DESCRIPTION
# Why?

The presentation would break if we tried to dismiss the bottom sheet before the presentation transition finished. 

# What?

- Checks `transitionState` in `DidTapDimView` and `DidReachDismissArea`. If `transitionState` is `.presenting` dismiss the `bottomSheetView` directly and set transition to cancelleded.
- Set `transitionState` to `nil` after completing transition

# Show me

| Before | After |
| --- | --- |
| ![cancel-presentation-broken](https://user-images.githubusercontent.com/19956175/69877377-55c2b300-12c2-11ea-9726-a08a675c7e42.gif) | ![cancel-presentation](https://user-images.githubusercontent.com/19956175/69877395-607d4800-12c2-11ea-9e08-0c3159376022.gif) |