### PR TITLE
Support navigation controllers

### DIFF
--- a/Demo/DemoViewController.swift
+++ b/Demo/DemoViewController.swift
@@ -64,15 +64,12 @@ final class DemoViewController: UIViewController {
             view.topAnchor.constraint(equalTo: viewController.view.topAnchor),
             view.leadingAnchor.constraint(equalTo: viewController.view.leadingAnchor),
             view.trailingAnchor.constraint(equalTo: viewController.view.trailingAnchor),
-            view.heightAnchor.constraint(equalToConstant: 400),
             view.bottomAnchor.constraint(equalTo: viewController.view.bottomAnchor)
         ])
 
         let navigationController = UINavigationController(rootViewController: viewController)
         navigationController.transitioningDelegate = bottomSheetTransitioningDelegate
         navigationController.modalPresentationStyle = .custom
-        navigationController.title = "My Navigation Controller"
-        navigationController.view.backgroundColor = .white
 
         present(navigationController, animated: true)
     }

--- a/Demo/DemoViewController.swift
+++ b/Demo/DemoViewController.swift
@@ -23,16 +23,21 @@ final class DemoViewController: UIViewController {
         view.backgroundColor = .white
 
         let buttonA = UIButton(type: .system)
-        buttonA.setTitle("View Controller", for: .normal)
+        buttonA.setTitle("Navigation View Controller", for: .normal)
         buttonA.titleLabel?.font = .systemFont(ofSize: 18)
-        buttonA.addTarget(self, action: #selector(presentViewController), for: .touchUpInside)
+        buttonA.addTarget(self, action: #selector(presentNavigationViewController), for: .touchUpInside)
 
         let buttonB = UIButton(type: .system)
-        buttonB.setTitle("View", for: .normal)
+        buttonB.setTitle("View Controller", for: .normal)
         buttonB.titleLabel?.font = .systemFont(ofSize: 18)
-        buttonB.addTarget(self, action: #selector(presentView), for: .touchUpInside)
+        buttonB.addTarget(self, action: #selector(presentViewController), for: .touchUpInside)
 
-        let stackView = UIStackView(arrangedSubviews: [buttonA, buttonB])
+        let buttonC = UIButton(type: .system)
+        buttonC.setTitle("View", for: .normal)
+        buttonC.titleLabel?.font = .systemFont(ofSize: 18)
+        buttonC.addTarget(self, action: #selector(presentView), for: .touchUpInside)
+
+        let stackView = UIStackView(arrangedSubviews: [buttonA, buttonB, buttonC])
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.axis = .vertical
 
@@ -42,6 +47,34 @@ final class DemoViewController: UIViewController {
             stackView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             stackView.centerYAnchor.constraint(equalTo: view.centerYAnchor)
         ])
+    }
+
+    // MARK: - Presentation logic
+
+    @objc private func presentNavigationViewController() {
+        let viewController = UIViewController()
+        viewController.title = "My View Controller"
+
+        let view = UIView.makeView(withTitle: "UIViewController in Navigation Controller")
+        viewController.view.backgroundColor = .red
+
+        viewController.view.addSubview(view)
+
+        NSLayoutConstraint.activate([
+            view.topAnchor.constraint(equalTo: viewController.view.topAnchor),
+            view.leadingAnchor.constraint(equalTo: viewController.view.leadingAnchor),
+            view.trailingAnchor.constraint(equalTo: viewController.view.trailingAnchor),
+            view.heightAnchor.constraint(equalToConstant: 400),
+            view.bottomAnchor.constraint(equalTo: viewController.view.bottomAnchor)
+        ])
+
+        let navigationController = UINavigationController(rootViewController: viewController)
+        navigationController.transitioningDelegate = bottomSheetTransitioningDelegate
+        navigationController.modalPresentationStyle = .custom
+        navigationController.title = "My Navigation Controller"
+        navigationController.view.backgroundColor = .white
+
+        present(navigationController, animated: true)
     }
 
     // MARK: - Presentation logic

--- a/Demo/DemoViewController.swift
+++ b/Demo/DemoViewController.swift
@@ -60,13 +60,14 @@ final class DemoViewController: UIViewController {
         viewController.view.addSubview(view)
 
         NSLayoutConstraint.activate([
-            view.topAnchor.constraint(equalTo: viewController.view.safeAreaLayoutGuide.topAnchor, constant: 16),
+            view.topAnchor.constraint(equalTo: viewController.view.topAnchor, constant: 16),
             view.leadingAnchor.constraint(equalTo: viewController.view.leadingAnchor),
             view.trailingAnchor.constraint(equalTo: viewController.view.trailingAnchor),
             view.bottomAnchor.constraint(equalTo: viewController.view.bottomAnchor)
         ])
 
         let navigationController = UINavigationController(rootViewController: viewController)
+        navigationController.navigationBar.isTranslucent = false
         navigationController.transitioningDelegate = bottomSheetTransitioningDelegate
         navigationController.modalPresentationStyle = .custom
 

--- a/Demo/DemoViewController.swift
+++ b/Demo/DemoViewController.swift
@@ -56,12 +56,11 @@ final class DemoViewController: UIViewController {
         viewController.title = "My View Controller"
 
         let view = UIView.makeView(withTitle: "UIViewController in Navigation Controller")
-        viewController.view.backgroundColor = .red
-
+        viewController.view.backgroundColor = view.backgroundColor
         viewController.view.addSubview(view)
 
         NSLayoutConstraint.activate([
-            view.topAnchor.constraint(equalTo: viewController.view.topAnchor),
+            view.topAnchor.constraint(equalTo: viewController.view.safeAreaLayoutGuide.topAnchor, constant: 16),
             view.leadingAnchor.constraint(equalTo: viewController.view.leadingAnchor),
             view.trailingAnchor.constraint(equalTo: viewController.view.trailingAnchor),
             view.bottomAnchor.constraint(equalTo: viewController.view.bottomAnchor)

--- a/Sources/BottomSheetCalculator.swift
+++ b/Sources/BottomSheetCalculator.swift
@@ -5,6 +5,8 @@
 import UIKit
 
 struct BottomSheetCalculator {
+    private static let handleHeight: CGFloat = 20
+
     /// Calculates offset for the given content view within its superview, taking preferred height into account.
     ///
     /// - Parameters:
@@ -12,27 +14,30 @@ struct BottomSheetCalculator {
     ///   - superview: the bottom sheet container view
     ///   - height: preferred height for the content view
     static func offset(for contentView: UIView, in superview: UIView, height: CGFloat) -> CGFloat {
-        let handleHeight: CGFloat = 20
         var targetHeight = contentHeight(for: contentView, in: superview, height: height)
 
         if height == .bottomSheetAutomatic {
-            targetHeight += handleHeight
+            targetHeight += BottomSheetCalculator.handleHeight
         }
 
-        return max(superview.frame.height - targetHeight, handleHeight)
+        return max(superview.frame.height - targetHeight, BottomSheetCalculator.handleHeight)
     }
 
     static func contentHeight(for contentView: UIView, in superview: UIView, height: CGFloat) -> CGFloat {
+        let contentHeight: CGFloat
+
         if height == .bottomSheetAutomatic {
             let size = contentView.systemLayoutSizeFitting(
                 superview.frame.size,
                 withHorizontalFittingPriority: .required,
                 verticalFittingPriority: .fittingSizeLevel
             )
-            return size.height
+            contentHeight = size.height
         } else {
-            return height
+            contentHeight = height
         }
+
+        return min(contentHeight, superview.frame.height - 64 - BottomSheetCalculator.handleHeight)
     }
 
     /// Creates the translation targets of a BottomSheetView based on an array of target offsets and the current target offset

--- a/Sources/BottomSheetCalculator.swift
+++ b/Sources/BottomSheetCalculator.swift
@@ -37,7 +37,7 @@ struct BottomSheetCalculator {
             contentHeight = height
         }
 
-        return min(contentHeight, superview.frame.height - 64 - BottomSheetCalculator.handleHeight)
+        return min(contentHeight, UIScreen.main.bounds.height - 64 - BottomSheetCalculator.handleHeight)
     }
 
     /// Creates the translation targets of a BottomSheetView based on an array of target offsets and the current target offset

--- a/Sources/BottomSheetCalculator.swift
+++ b/Sources/BottomSheetCalculator.swift
@@ -5,7 +5,7 @@
 import UIKit
 
 struct BottomSheetCalculator {
-    private static let handleHeight: CGFloat = 20
+    static let handleHeight: CGFloat = 20
 
     /// Calculates offset for the given content view within its superview, taking preferred height into account.
     ///

--- a/Sources/BottomSheetView.swift
+++ b/Sources/BottomSheetView.swift
@@ -130,9 +130,8 @@ public final class BottomSheetView: UIView {
         updateTargetOffsets()
 
         if let maxOffset = targetOffsets.max() {
-            let minHeight = superview.frame.size.height - maxOffset
-            let constant = BottomSheetCalculator.contentHeight(for: contentView, in: superview, height: minHeight)
-            constraints.append(contentView.heightAnchor.constraint(greaterThanOrEqualToConstant: constant))
+            let contentViewHeight = superview.frame.size.height - maxOffset - BottomSheetCalculator.handleHeight
+            constraints.append(contentView.heightAnchor.constraint(greaterThanOrEqualToConstant: contentViewHeight))
         }
 
         NSLayoutConstraint.activate(constraints)
@@ -190,7 +189,7 @@ public final class BottomSheetView: UIView {
 
     private func setup() {
         clipsToBounds = true
-        backgroundColor = contentView.backgroundColor
+        backgroundColor = contentView.backgroundColor ?? .bgPrimary
 
         layer.masksToBounds = false
         layer.shadowColor = UIColor.black.cgColor
@@ -309,14 +308,26 @@ public final class BottomSheetView: UIView {
 
 private extension UIColor {
     class var handle: UIColor {
-        let defaultColor = UIColor(red: 195/255, green: 204/255, blue: 217/255, alpha: 1)
+        return dynamicColorIfAvailable(
+            defaultColor: UIColor(red: 195/255, green: 204/255, blue: 217/255, alpha: 1),
+            darkModeColor: UIColor(red: 67/255, green: 67/255, blue: 89/255, alpha: 1)
+        )
+    }
 
+    class var bgPrimary: UIColor {
+        return dynamicColorIfAvailable(
+            defaultColor: .white,
+            darkModeColor: UIColor(red: 27/255, green: 27/255, blue: 36/255, alpha: 1)
+        )
+    }
+
+    class func dynamicColorIfAvailable(defaultColor: UIColor, darkModeColor: UIColor) -> UIColor {
         if #available(iOS 13.0, *) {
             #if swift(>=5.1)
             return UIColor { traitCollection -> UIColor in
                 switch traitCollection.userInterfaceStyle {
                 case .dark:
-                    return UIColor(red: 67/255, green: 67/255, blue: 89/255, alpha: 1)
+                    return darkModeColor
                 default:
                     return defaultColor
                 }

--- a/Sources/BottomSheetView.swift
+++ b/Sources/BottomSheetView.swift
@@ -120,17 +120,25 @@ public final class BottomSheetView: UIView {
 
         springAnimator.addCompletion { didComplete in completion?(didComplete) }
 
-        NSLayoutConstraint.activate([
+        var constraints: [NSLayoutConstraint] = [
             topConstraint,
             bottomAnchor.constraint(greaterThanOrEqualTo: superview.bottomAnchor),
             leadingAnchor.constraint(equalTo: superview.leadingAnchor),
             trailingAnchor.constraint(equalTo: superview.trailingAnchor)
-        ])
+        ]
 
+        updateTargetOffsets()
+
+        if let maxOffset = targetOffsets.max() {
+            let minHeight = superview.frame.size.height - maxOffset
+            let constant = BottomSheetCalculator.contentHeight(for: contentView, in: superview, height: minHeight)
+            constraints.append(contentView.heightAnchor.constraint(greaterThanOrEqualToConstant: constant))
+        }
+
+        NSLayoutConstraint.activate(constraints)
         superview.layoutIfNeeded()
         addGestureRecognizer(panGesture)
 
-        updateTargetOffsets()
         transition(to: targetIndex)
         createTranslationTargets()
     }


### PR DESCRIPTION
# Why?

@ag12 found an issue with `UINavigationController` not displaying properly within the bottom sheet. As it turned out, we didn't really support views without explicit height.

# What?

- @ag12 added a demo to test navigation controllers
- Set min height constraint for the content view (based on calculated max target offset)
- Made bottom sheet height to be less than or equal to superview height - 64, because otherwise the handle overlaps with iPhone notch.
- Added default background color for cases when background color of the presented view is not specified.

# Show me

![navi](https://user-images.githubusercontent.com/10529867/70061290-4f934600-15e4-11ea-8509-d563ce47bf75.gif)
