### PR TITLE
Initialize BottomSheetView with contentHeights

### DIFF
--- a/Demo/DemoViewController.swift
+++ b/Demo/DemoViewController.swift
@@ -7,7 +7,7 @@ import BottomSheet
 
 final class DemoViewController: UIViewController {
     private lazy var bottomSheetTransitioningDelegate = BottomSheetTransitioningDelegate(
-        targetHeights: [.bottomSheetAutomatic, UIScreen.main.bounds.size.height - 200]
+        contentHeights: [.bottomSheetAutomatic, UIScreen.main.bounds.size.height - 200]
     )
 
     // MARK: - Lifecycle
@@ -99,7 +99,7 @@ final class DemoViewController: UIViewController {
     @objc private func presentView() {
         let bottomSheetView = BottomSheetView(
             contentView: UIView.makeView(withTitle: "UIView"),
-            targetHeights: [100, 500]
+            contentHeights: [100, 500]
         )
         bottomSheetView.present(in: view)
     }

--- a/Sources/BottomSheetCalculator.swift
+++ b/Sources/BottomSheetCalculator.swift
@@ -4,8 +4,11 @@
 
 import UIKit
 
-struct BottomSheetCalculator {
+extension CGFloat {
     static let handleHeight: CGFloat = 20
+}
+
+struct BottomSheetCalculator {
 
     /// Calculates offset for the given content view within its superview, taking preferred height into account.
     ///
@@ -14,13 +17,8 @@ struct BottomSheetCalculator {
     ///   - superview: the bottom sheet container view
     ///   - height: preferred height for the content view
     static func offset(for contentView: UIView, in superview: UIView, height: CGFloat) -> CGFloat {
-        var targetHeight = contentHeight(for: contentView, in: superview, height: height)
-
-        if height == .bottomSheetAutomatic {
-            targetHeight += BottomSheetCalculator.handleHeight
-        }
-
-        return max(superview.frame.height - targetHeight, BottomSheetCalculator.handleHeight)
+        let targetHeight = contentHeight(for: contentView, in: superview, height: height) + .handleHeight
+        return max(superview.frame.height - targetHeight, .handleHeight)
     }
 
     static func contentHeight(for contentView: UIView, in superview: UIView, height: CGFloat) -> CGFloat {
@@ -37,7 +35,7 @@ struct BottomSheetCalculator {
             contentHeight = height
         }
 
-        return min(contentHeight, UIScreen.main.bounds.height - 64 - BottomSheetCalculator.handleHeight)
+        return min(contentHeight, UIScreen.main.bounds.height - 64 - .handleHeight)
     }
 
     /// Creates the translation targets of a BottomSheetView based on an array of target offsets and the current target offset

--- a/Sources/BottomSheetPresentationController.swift
+++ b/Sources/BottomSheetPresentationController.swift
@@ -19,7 +19,7 @@ final class BottomSheetPresentationController: UIPresentationController {
 
     // MARK: - Private properties
 
-    private let targetHeights: [CGFloat]
+    private let contentHeights: [CGFloat]
     private let startTargetIndex: Int
     private var dismissVelocity: CGPoint = .zero
     private var bottomSheetView: BottomSheetView?
@@ -30,10 +30,10 @@ final class BottomSheetPresentationController: UIPresentationController {
     init(
         presentedViewController: UIViewController,
         presenting: UIViewController?,
-        targetHeights: [CGFloat],
+        contentHeights: [CGFloat],
         startTargetIndex: Int
     ) {
-        self.targetHeights = targetHeights
+        self.contentHeights = contentHeights
         self.startTargetIndex = startTargetIndex
         super.init(presentedViewController: presentedViewController, presenting: presenting)
     }
@@ -65,7 +65,7 @@ final class BottomSheetPresentationController: UIPresentationController {
         let contentHeight = BottomSheetCalculator.contentHeight(
             for: presentedView,
             in: containerView,
-            height: targetHeights[startTargetIndex]
+            height: contentHeights[startTargetIndex]
         )
 
         let size = CGSize(
@@ -84,7 +84,7 @@ final class BottomSheetPresentationController: UIPresentationController {
 
         bottomSheetView = BottomSheetView(
             contentView: presentedView,
-            targetHeights: targetHeights,
+            contentHeights: contentHeights,
             isDismissible: true
         )
 

--- a/Sources/BottomSheetTransitioningDelegate.swift
+++ b/Sources/BottomSheetTransitioningDelegate.swift
@@ -5,14 +5,14 @@
 import UIKit
 
 public final class BottomSheetTransitioningDelegate: NSObject {
-    private let preferredHeights: [CGFloat]
+    private let contentHeights: [CGFloat]
     private let startTargetIndex: Int
     private var presentationController: BottomSheetPresentationController?
 
     // MARK: - Init
 
-    public init(targetHeights: [CGFloat], startTargetIndex: Int = 0) {
-        self.preferredHeights = targetHeights
+    public init(contentHeights: [CGFloat], startTargetIndex: Int = 0) {
+        self.contentHeights = contentHeights
         self.startTargetIndex = startTargetIndex
     }
 }
@@ -28,7 +28,7 @@ extension BottomSheetTransitioningDelegate: UIViewControllerTransitioningDelegat
         presentationController = BottomSheetPresentationController(
             presentedViewController: presented,
             presenting: presenting,
-            targetHeights: preferredHeights,
+            contentHeights: contentHeights,
             startTargetIndex: startTargetIndex
         )
         return presentationController

--- a/Sources/BottomSheetView.swift
+++ b/Sources/BottomSheetView.swift
@@ -32,7 +32,7 @@ public final class BottomSheetView: UIView {
     private let isDismissable: Bool
     private let contentView: UIView
     private var topConstraint: NSLayoutConstraint!
-    private let targetHeights: [CGFloat]
+    private let contentHeights: [CGFloat]
     private var targetOffsets = [CGFloat]()
     private var currentTargetOffsetIndex: Int = 0
 
@@ -63,9 +63,9 @@ public final class BottomSheetView: UIView {
 
     // MARK: - Init
 
-    public init(contentView: UIView, targetHeights: [CGFloat], isDismissible: Bool = false) {
+    public init(contentView: UIView, contentHeights: [CGFloat], isDismissible: Bool = false) {
         self.contentView = contentView
-        self.targetHeights = targetHeights.isEmpty ? [.bottomSheetAutomatic] : targetHeights
+        self.contentHeights = contentHeights.isEmpty ? [.bottomSheetAutomatic] : contentHeights
         self.isDismissable = isDismissible
         super.init(frame: .zero)
         setup()
@@ -103,7 +103,7 @@ public final class BottomSheetView: UIView {
         let startOffset = BottomSheetCalculator.offset(
             for: contentView,
             in: superview,
-            height: targetHeights[targetIndex]
+            height: contentHeights[targetIndex]
         )
 
         if animated {
@@ -130,7 +130,7 @@ public final class BottomSheetView: UIView {
         updateTargetOffsets()
 
         if let maxOffset = targetOffsets.max() {
-            let contentViewHeight = superview.frame.size.height - maxOffset - BottomSheetCalculator.handleHeight
+            let contentViewHeight = superview.frame.size.height - maxOffset - .handleHeight
             constraints.append(contentView.heightAnchor.constraint(greaterThanOrEqualToConstant: contentViewHeight))
         }
 
@@ -172,7 +172,7 @@ public final class BottomSheetView: UIView {
     /// - Parameters:
     ///   - index: the index of the target height
     public func transition(to index: Int) {
-        guard targetHeights.indices.contains(index) else {
+        guard contentHeights.indices.contains(index) else {
             assertionFailure("Provided index is out of bounds of the array with target heights.")
             return
         }
@@ -181,7 +181,7 @@ public final class BottomSheetView: UIView {
             return
         }
 
-        let offset = BottomSheetCalculator.offset(for: contentView, in: superview, height: targetHeights[index])
+        let offset = BottomSheetCalculator.offset(for: contentView, in: superview, height: contentHeights[index])
         animate(to: offset)
     }
 
@@ -287,7 +287,7 @@ public final class BottomSheetView: UIView {
     private func updateTargetOffsets() {
         guard let superview = superview else { return }
 
-        targetOffsets = targetHeights.map {
+        targetOffsets = contentHeights.map {
             BottomSheetCalculator.offset(for: contentView, in: superview, height: $0)
         }.sorted(by: >)
     }

--- a/Tests/BottomSheetCalculatorTests.swift
+++ b/Tests/BottomSheetCalculatorTests.swift
@@ -15,15 +15,15 @@ final class BottomSheetCalculatorTests: XCTestCase {
     }
 
     func testOffsetWithHeightSmallerThanSuperviewHeight() {
-        XCTAssertEqual(BottomSheetCalculator.offset(for: view, in: superview, height: 300), 100) // 400 - 300
+        XCTAssertEqual(BottomSheetCalculator.offset(for: view, in: superview, height: 300), 100 - .handleHeight) // 400 - 300 - .handleHeight
     }
 
     func testOffsetWithHeightBiggerThanSuperviewHeight() {
-        XCTAssertEqual(BottomSheetCalculator.offset(for: view, in: superview, height: 500), 20) // Handle height
+        XCTAssertEqual(BottomSheetCalculator.offset(for: view, in: superview, height: 500), .handleHeight) // Handle height
     }
 
     func testOffsetWithZeroHeight() {
-        XCTAssertEqual(BottomSheetCalculator.offset(for: view, in: superview, height: 0), 400) // Superview height
+        XCTAssertEqual(BottomSheetCalculator.offset(for: view, in: superview, height: 0), 400 - .handleHeight) // Superview height - .handleHeight
     }
 
     func testLayoutWithEmptyOffsets() {


### PR DESCRIPTION
# Why?

Not being consistent with adding handle height to automatic height and not other target heights got a bit confusing. Changing from `targetHeights` to `contentHeights` and always add handle height will make it less confusing and more consistent.

# What?

- Changed all `targetHeights` to `contentHeights` 
- Make `.handleHeight` a `CGFloat` extension
- Always adds `.handleHeight` to content height when calculating target offsets
- Update tests