### PR TITLE
Use safe area bottom inset when needed

### DIFF
--- a/Demo/DemoViewController.swift
+++ b/Demo/DemoViewController.swift
@@ -82,7 +82,7 @@ final class DemoViewController: UIViewController {
         viewController.modalPresentationStyle = .custom
 
         let view = UIView.makeView(withTitle: "UIViewController")
-        viewController.view.backgroundColor = view.backgroundColor
+        viewController.view.backgroundColor = .red
         viewController.view.addSubview(view)
 
         NSLayoutConstraint.activate([

--- a/Sources/BottomSheetCalculator.swift
+++ b/Sources/BottomSheetCalculator.swift
@@ -23,7 +23,7 @@ struct BottomSheetCalculator {
         for contentView: UIView,
         in superview: UIView,
         height: CGFloat,
-        useSafeAreaInsets: Bool
+        useSafeAreaInsets: Bool = false
     ) -> CGFloat {
         let targetHeight = contentHeight(
             for: contentView,
@@ -39,7 +39,7 @@ struct BottomSheetCalculator {
         for contentView: UIView,
         in superview: UIView,
         height: CGFloat,
-        useSafeAreaInsets: Bool
+        useSafeAreaInsets: Bool = false
     ) -> CGFloat {
         let contentHeight: CGFloat
         let bottomInset: CGFloat = useSafeAreaInsets ? .safeAreaBottomInset : 0

--- a/Sources/BottomSheetCalculator.swift
+++ b/Sources/BottomSheetCalculator.swift
@@ -6,23 +6,43 @@ import UIKit
 
 extension CGFloat {
     static let handleHeight: CGFloat = 20
+
+    static var safeAreaBottomInset: CGFloat {
+        return UIApplication.shared.keyWindow?.safeAreaInsets.bottom ?? 0
+    }
 }
 
 struct BottomSheetCalculator {
-
     /// Calculates offset for the given content view within its superview, taking preferred height into account.
     ///
     /// - Parameters:
     ///   - contentView: the content view of the bottom sheet
     ///   - superview: the bottom sheet container view
     ///   - height: preferred height for the content view
-    static func offset(for contentView: UIView, in superview: UIView, height: CGFloat) -> CGFloat {
-        let targetHeight = contentHeight(for: contentView, in: superview, height: height) + .handleHeight
+    static func offset(
+        for contentView: UIView,
+        in superview: UIView,
+        height: CGFloat,
+        useSafeAreaInsets: Bool
+    ) -> CGFloat {
+        let targetHeight = contentHeight(
+            for: contentView,
+            in: superview,
+            height: height,
+            useSafeAreaInsets: useSafeAreaInsets
+        ) + .handleHeight
+
         return max(superview.frame.height - targetHeight, .handleHeight)
     }
 
-    static func contentHeight(for contentView: UIView, in superview: UIView, height: CGFloat) -> CGFloat {
+    static func contentHeight(
+        for contentView: UIView,
+        in superview: UIView,
+        height: CGFloat,
+        useSafeAreaInsets: Bool
+    ) -> CGFloat {
         let contentHeight: CGFloat
+        let bottomInset: CGFloat = useSafeAreaInsets ? .safeAreaBottomInset : 0
 
         if height == .bottomSheetAutomatic {
             let size = contentView.systemLayoutSizeFitting(
@@ -35,7 +55,7 @@ struct BottomSheetCalculator {
             contentHeight = height
         }
 
-        return min(contentHeight, UIScreen.main.bounds.height - 64 - .handleHeight)
+        return min(contentHeight + bottomInset, UIScreen.main.bounds.height - 64 - .handleHeight)
     }
 
     /// Creates the translation targets of a BottomSheetView based on an array of target offsets and the current target offset

--- a/Sources/BottomSheetPresentationController.swift
+++ b/Sources/BottomSheetPresentationController.swift
@@ -21,6 +21,7 @@ final class BottomSheetPresentationController: UIPresentationController {
 
     private let contentHeights: [CGFloat]
     private let startTargetIndex: Int
+    private let useSafeAreaInsets: Bool
     private var dismissVelocity: CGPoint = .zero
     private var bottomSheetView: BottomSheetView?
     private weak var transitionContext: UIViewControllerContextTransitioning?
@@ -31,10 +32,12 @@ final class BottomSheetPresentationController: UIPresentationController {
         presentedViewController: UIViewController,
         presenting: UIViewController?,
         contentHeights: [CGFloat],
-        startTargetIndex: Int
+        startTargetIndex: Int,
+        useSafeAreaInsets: Bool
     ) {
         self.contentHeights = contentHeights
         self.startTargetIndex = startTargetIndex
+        self.useSafeAreaInsets = useSafeAreaInsets
         super.init(presentedViewController: presentedViewController, presenting: presenting)
     }
 
@@ -65,7 +68,8 @@ final class BottomSheetPresentationController: UIPresentationController {
         let contentHeight = BottomSheetCalculator.contentHeight(
             for: presentedView,
             in: containerView,
-            height: contentHeights[startTargetIndex]
+            height: contentHeights[startTargetIndex],
+            useSafeAreaInsets: useSafeAreaInsets
         )
 
         let size = CGSize(
@@ -85,6 +89,7 @@ final class BottomSheetPresentationController: UIPresentationController {
         bottomSheetView = BottomSheetView(
             contentView: presentedView,
             contentHeights: contentHeights,
+            useSafeAreaInsets: useSafeAreaInsets,
             isDismissible: true
         )
 

--- a/Sources/BottomSheetTransitioningDelegate.swift
+++ b/Sources/BottomSheetTransitioningDelegate.swift
@@ -7,13 +7,15 @@ import UIKit
 public final class BottomSheetTransitioningDelegate: NSObject {
     private let contentHeights: [CGFloat]
     private let startTargetIndex: Int
+    private let useSafeAreaInsets: Bool
     private var presentationController: BottomSheetPresentationController?
 
     // MARK: - Init
 
-    public init(contentHeights: [CGFloat], startTargetIndex: Int = 0) {
+    public init(contentHeights: [CGFloat], startTargetIndex: Int = 0, useSafeAreaInsets: Bool = false) {
         self.contentHeights = contentHeights
         self.startTargetIndex = startTargetIndex
+        self.useSafeAreaInsets = useSafeAreaInsets
     }
 }
 
@@ -29,7 +31,8 @@ extension BottomSheetTransitioningDelegate: UIViewControllerTransitioningDelegat
             presentedViewController: presented,
             presenting: presenting,
             contentHeights: contentHeights,
-            startTargetIndex: startTargetIndex
+            startTargetIndex: startTargetIndex,
+            useSafeAreaInsets: useSafeAreaInsets
         )
         return presentationController
     }


### PR DESCRIPTION
# Why?

Because sometimes we want to consider safe area insets when calculating the content view height and target offsets.

# What?

Add `useSafeAreaInsets` parameter to `BottomSheetTransitioningDelegate` and `BottomSheetView`. It's default to false.

# Show me

![Simulator Screen Shot - iPhone 11 Pro Max - 2019-12-20 at 09 35 35](https://user-images.githubusercontent.com/10529867/71241526-1f4de600-230c-11ea-994e-c10aecacc976.png)
