### PR TITLE
Add a helper class to work with navigation controllers

### DIFF
--- a/BottomSheet.xcodeproj/project.pbxproj
+++ b/BottomSheet.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		CF46A383238593AD00FFCB9F /* BottomSheetCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF46A3812385902100FFCB9F /* BottomSheetCalculator.swift */; };
 		DA0F4B00238BDB85002DE188 /* TranslationTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA0F4AFE238BDB7C002DE188 /* TranslationTarget.swift */; };
 		DA11525523880010002E2F40 /* BottomSheetModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA11525323880010002E2F40 /* BottomSheetModelTests.swift */; };
+		DACFE66423AC29BE006B352F /* BottomSheetNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DACFE66023AC2626006B352F /* BottomSheetNavigationController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -76,6 +77,7 @@
 		CF46A3812385902100FFCB9F /* BottomSheetCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetCalculator.swift; sourceTree = "<group>"; };
 		DA0F4AFE238BDB7C002DE188 /* TranslationTarget.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TranslationTarget.swift; sourceTree = "<group>"; };
 		DA11525323880010002E2F40 /* BottomSheetModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetModelTests.swift; sourceTree = "<group>"; };
+		DACFE66023AC2626006B352F /* BottomSheetNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetNavigationController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -131,12 +133,13 @@
 			children = (
 				CF1539C02382F20E001687C1 /* BottomSheet.h */,
 				CF1539C12382F20E001687C1 /* Info.plist */,
-				DA0F4AFE238BDB7C002DE188 /* TranslationTarget.swift */,
 				CF46A3812385902100FFCB9F /* BottomSheetCalculator.swift */,
+				DACFE66023AC2626006B352F /* BottomSheetNavigationController.swift */,
 				CF1539F12382F621001687C1 /* BottomSheetPresentationController.swift */,
 				CF1539F32382F621001687C1 /* BottomSheetTransitioningDelegate.swift */,
 				CF1539F52382F621001687C1 /* BottomSheetView.swift */,
 				CF1539F42382F621001687C1 /* SpringAnimator.swift */,
+				DA0F4AFE238BDB7C002DE188 /* TranslationTarget.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -338,6 +341,7 @@
 				CF1539FC2382F62A001687C1 /* BottomSheetTransitioningDelegate.swift in Sources */,
 				DA0F4B00238BDB85002DE188 /* TranslationTarget.swift in Sources */,
 				CF1539FF2382F62A001687C1 /* SpringAnimator.swift in Sources */,
+				DACFE66423AC29BE006B352F /* BottomSheetNavigationController.swift in Sources */,
 				CF1539FD2382F62A001687C1 /* BottomSheetView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Demo/DemoViewController.swift
+++ b/Demo/DemoViewController.swift
@@ -52,7 +52,7 @@ final class DemoViewController: UIViewController {
     // MARK: - Presentation logic
 
     @objc private func presentNavigationViewController() {
-        let viewController = ViewController(withNavigationButton: true, title: "Step 1", contentHeight: 400)
+        let viewController = ViewController(withNavigationButton: true, contentHeight: 400)
         let navigationController = BottomSheetNavigationController(rootViewController: viewController)
         navigationController.navigationBar.isTranslucent = false
         present(navigationController, animated: true)
@@ -61,7 +61,7 @@ final class DemoViewController: UIViewController {
     // MARK: - Presentation logic
 
     @objc private func presentViewController() {
-        let viewController = ViewController(withNavigationButton: false, title: "UIViewConteoller", contentHeight: 400)
+        let viewController = ViewController(withNavigationButton: false, text: "UIViewController", contentHeight: 400)
         viewController.transitioningDelegate = bottomSheetTransitioningDelegate
         viewController.modalPresentationStyle = .custom
         present(viewController, animated: true)
@@ -104,9 +104,11 @@ private extension UIView {
 private final class ViewController: UIViewController {
     private let withNavigationButton: Bool
     private let contentHeight: CGFloat
+    private let text: String?
 
-    init(withNavigationButton: Bool, title: String, contentHeight: CGFloat) {
+    init(withNavigationButton: Bool, text: String? = nil, contentHeight: CGFloat) {
         self.withNavigationButton = withNavigationButton
+        self.text = text
         self.contentHeight = contentHeight
         super.init(nibName: nil, bundle: nil)
         self.title = title
@@ -119,7 +121,7 @@ private final class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        let contentView = UIView.makeView(withTitle: withNavigationButton ? nil : title)
+        let contentView = UIView.makeView(withTitle: text)
         view.backgroundColor = contentView.backgroundColor
         view.addSubview(contentView)
 
@@ -132,6 +134,8 @@ private final class ViewController: UIViewController {
         ])
 
         if withNavigationButton {
+            title = "Step 1"
+
             let button = UIButton(type: .system)
             button.translatesAutoresizingMaskIntoConstraints = false
             button.titleLabel?.font = UIFont.boldSystemFont(ofSize: 20)
@@ -148,7 +152,11 @@ private final class ViewController: UIViewController {
     }
 
     @objc private func handleButtonTap() {
-        let viewController = ViewController(withNavigationButton: false, title: "Step 2", contentHeight: contentHeight - 100)
+        let viewController = ViewController(
+            withNavigationButton: false,
+            text: "Step 2",
+            contentHeight: contentHeight - 100
+        )
         navigationController?.pushViewController(viewController, animated: true)
     }
 }

--- a/Demo/DemoViewController.swift
+++ b/Demo/DemoViewController.swift
@@ -125,7 +125,7 @@ private final class ViewController: UIViewController {
         super.viewDidLoad()
 
         let contentView = UIView.makeView(withTitle: text)
-        view.backgroundColor = contentView.backgroundColor
+        view.backgroundColor = .red
         view.addSubview(contentView)
 
         NSLayoutConstraint.activate([
@@ -133,8 +133,9 @@ private final class ViewController: UIViewController {
             contentView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             contentView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             contentView.heightAnchor.constraint(equalToConstant: contentHeight),
-            contentView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
+
+        preferredContentSize.height = contentHeight
 
         if withNavigationButton {
             let button = UIButton(type: .system)
@@ -147,52 +148,13 @@ private final class ViewController: UIViewController {
 
             NSLayoutConstraint.activate([
                 button.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-                button.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+                button.centerYAnchor.constraint(equalTo: contentView.centerYAnchor)
             ])
         }
     }
 
     @objc private func handleButtonTap() {
         let viewController = ViewController(withNavigationButton: false, contentHeight: contentHeight - 100)
-        viewController.title = "Step 2"
-        navigationController?.pushViewController(viewController, animated: true)
-    }
-}
-
-class TableViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
-    private lazy var tableView = UITableView()
-    let items = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        view.addSubview(tableView)
-        tableView.delegate = self
-        tableView.dataSource = self
-        tableView.translatesAutoresizingMaskIntoConstraints = false
-
-        NSLayoutConstraint.activate([
-            tableView.topAnchor.constraint(equalTo: view.topAnchor),
-            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
-        ])
-
-        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "cell")
-        tableView.reloadData()
-    }
-
-    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return items.count
-    }
-
-    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath)
-        cell.textLabel?.text = "\(items[indexPath.item])"
-        return cell
-    }
-
-    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        let viewController = ViewController(withNavigationButton: false, contentHeight: 300)
         viewController.title = "Step 2"
         navigationController?.pushViewController(viewController, animated: true)
     }

--- a/Demo/DemoViewController.swift
+++ b/Demo/DemoViewController.swift
@@ -158,3 +158,42 @@ private final class ViewController: UIViewController {
         navigationController?.pushViewController(viewController, animated: true)
     }
 }
+
+class TableViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
+    private lazy var tableView = UITableView()
+    let items = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.addSubview(tableView)
+        tableView.delegate = self
+        tableView.dataSource = self
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            tableView.topAnchor.constraint(equalTo: view.topAnchor),
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "cell")
+        tableView.reloadData()
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return items.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath)
+        cell.textLabel?.text = "\(items[indexPath.item])"
+        return cell
+    }
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let viewController = ViewController(withNavigationButton: false, contentHeight: 300)
+        viewController.title = "Step 2"
+        navigationController?.pushViewController(viewController, animated: true)
+    }
+}

--- a/Demo/DemoViewController.swift
+++ b/Demo/DemoViewController.swift
@@ -94,10 +94,21 @@ private extension UIView {
         label.textColor = .white
         view.addSubview(label)
 
+        let borderView = UIView()
+        borderView.translatesAutoresizingMaskIntoConstraints = false
+        borderView.backgroundColor = .white
+        borderView.alpha = 0.4
+        view.addSubview(borderView)
+
         NSLayoutConstraint.activate([
-            label.topAnchor.constraint(equalTo: view.topAnchor),
+            label.topAnchor.constraint(equalTo: view.topAnchor, constant: 8),
             label.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            label.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+            label.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+
+            borderView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            borderView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            borderView.heightAnchor.constraint(equalToConstant: 2),
+            borderView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
 
         return view
@@ -125,7 +136,7 @@ private final class ViewController: UIViewController {
         super.viewDidLoad()
 
         let contentView = UIView.makeView(withTitle: text)
-        view.backgroundColor = .red
+        view.backgroundColor = contentView.backgroundColor
         view.addSubview(contentView)
 
         NSLayoutConstraint.activate([

--- a/Demo/DemoViewController.swift
+++ b/Demo/DemoViewController.swift
@@ -52,47 +52,18 @@ final class DemoViewController: UIViewController {
     // MARK: - Presentation logic
 
     @objc private func presentNavigationViewController() {
-        let viewController = UIViewController()
-        viewController.title = "My View Controller"
-
-        let view = UIView.makeView(withTitle: "UIViewController in Navigation Controller")
-        viewController.view.backgroundColor = view.backgroundColor
-        viewController.view.addSubview(view)
-
-        NSLayoutConstraint.activate([
-            view.topAnchor.constraint(equalTo: viewController.view.topAnchor, constant: 16),
-            view.leadingAnchor.constraint(equalTo: viewController.view.leadingAnchor),
-            view.trailingAnchor.constraint(equalTo: viewController.view.trailingAnchor),
-            view.bottomAnchor.constraint(equalTo: viewController.view.bottomAnchor)
-        ])
-
-        let navigationController = UINavigationController(rootViewController: viewController)
+        let viewController = ViewController(withNavigationButton: true, title: "Step 1", contentHeight: 400)
+        let navigationController = BottomSheetNavigationController(rootViewController: viewController)
         navigationController.navigationBar.isTranslucent = false
-        navigationController.transitioningDelegate = bottomSheetTransitioningDelegate
-        navigationController.modalPresentationStyle = .custom
-
         present(navigationController, animated: true)
     }
 
     // MARK: - Presentation logic
 
     @objc private func presentViewController() {
-        let viewController = UIViewController()
+        let viewController = ViewController(withNavigationButton: false, title: "UIViewConteoller", contentHeight: 400)
         viewController.transitioningDelegate = bottomSheetTransitioningDelegate
         viewController.modalPresentationStyle = .custom
-
-        let view = UIView.makeView(withTitle: "UIViewController")
-        viewController.view.backgroundColor = .red
-        viewController.view.addSubview(view)
-
-        NSLayoutConstraint.activate([
-            view.topAnchor.constraint(equalTo: viewController.view.topAnchor),
-            view.leadingAnchor.constraint(equalTo: viewController.view.leadingAnchor),
-            view.trailingAnchor.constraint(equalTo: viewController.view.trailingAnchor),
-            view.heightAnchor.constraint(equalToConstant: 400),
-            view.bottomAnchor.constraint(equalTo: viewController.view.bottomAnchor)
-        ])
-
         present(viewController, animated: true)
     }
 
@@ -108,16 +79,16 @@ final class DemoViewController: UIViewController {
 // MARK: - Private extensions
 
 private extension UIView {
-    static func makeView(withTitle title: String) -> UIView {
+    static func makeView(withTitle title: String? = nil) -> UIView {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.backgroundColor = UIColor(hue: 0.5, saturation: 0.3, brightness: 0.6, alpha: 1.0)
+
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.text = title
         label.textAlignment = .center
         label.textColor = .white
-
-        let view = UIView()
-        view.translatesAutoresizingMaskIntoConstraints = false
-        view.backgroundColor = UIColor(hue: 0.5, saturation: 0.3, brightness: 0.6, alpha: 1.0)
         view.addSubview(label)
 
         NSLayoutConstraint.activate([
@@ -127,5 +98,57 @@ private extension UIView {
         ])
 
         return view
+    }
+}
+
+private final class ViewController: UIViewController {
+    private let withNavigationButton: Bool
+    private let contentHeight: CGFloat
+
+    init(withNavigationButton: Bool, title: String, contentHeight: CGFloat) {
+        self.withNavigationButton = withNavigationButton
+        self.contentHeight = contentHeight
+        super.init(nibName: nil, bundle: nil)
+        self.title = title
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        let contentView = UIView.makeView(withTitle: withNavigationButton ? nil : title)
+        view.backgroundColor = contentView.backgroundColor
+        view.addSubview(contentView)
+
+        NSLayoutConstraint.activate([
+            contentView.topAnchor.constraint(equalTo: view.topAnchor),
+            contentView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            contentView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            contentView.heightAnchor.constraint(equalToConstant: contentHeight),
+            contentView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+
+        if withNavigationButton {
+            let button = UIButton(type: .system)
+            button.translatesAutoresizingMaskIntoConstraints = false
+            button.titleLabel?.font = UIFont.boldSystemFont(ofSize: 20)
+            button.setTitle("Next", for: .normal)
+            button.setTitleColor(.white, for: .normal)
+            button.addTarget(self, action: #selector(handleButtonTap), for: .touchUpInside)
+            view.addSubview(button)
+
+            NSLayoutConstraint.activate([
+                button.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+                button.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+            ])
+        }
+    }
+
+    @objc private func handleButtonTap() {
+        let viewController = ViewController(withNavigationButton: false, title: "Step 2", contentHeight: contentHeight - 100)
+        navigationController?.pushViewController(viewController, animated: true)
     }
 }

--- a/Demo/DemoViewController.swift
+++ b/Demo/DemoViewController.swift
@@ -53,8 +53,11 @@ final class DemoViewController: UIViewController {
 
     @objc private func presentNavigationViewController() {
         let viewController = ViewController(withNavigationButton: true, contentHeight: 400)
+        viewController.title = "Step 1"
+
         let navigationController = BottomSheetNavigationController(rootViewController: viewController)
         navigationController.navigationBar.isTranslucent = false
+
         present(navigationController, animated: true)
     }
 
@@ -134,8 +137,6 @@ private final class ViewController: UIViewController {
         ])
 
         if withNavigationButton {
-            title = "Step 1"
-
             let button = UIButton(type: .system)
             button.translatesAutoresizingMaskIntoConstraints = false
             button.titleLabel?.font = UIFont.boldSystemFont(ofSize: 20)
@@ -152,11 +153,8 @@ private final class ViewController: UIViewController {
     }
 
     @objc private func handleButtonTap() {
-        let viewController = ViewController(
-            withNavigationButton: false,
-            text: "Step 2",
-            contentHeight: contentHeight - 100
-        )
+        let viewController = ViewController(withNavigationButton: false, contentHeight: contentHeight - 100)
+        viewController.title = "Step 2"
         navigationController?.pushViewController(viewController, animated: true)
     }
 }

--- a/Sources/BottomSheetCalculator.swift
+++ b/Sources/BottomSheetCalculator.swift
@@ -45,12 +45,7 @@ struct BottomSheetCalculator {
         let bottomInset: CGFloat = useSafeAreaInsets ? .safeAreaBottomInset : 0
 
         if height == .bottomSheetAutomatic {
-            let size = contentView.systemLayoutSizeFitting(
-                superview.frame.size,
-                withHorizontalFittingPriority: .required,
-                verticalFittingPriority: .fittingSizeLevel
-            )
-            contentHeight = size.height
+            contentHeight = contentView.systemLayoutHeightFitting(superview.frame.size)
         } else {
             contentHeight = height
         }
@@ -137,5 +132,26 @@ struct BottomSheetCalculator {
         targets.append(topTarget)
 
         return targets
+    }
+}
+
+// MARK: - Extensions
+
+extension UIView {
+    func systemLayoutHeightFitting(_ size: CGSize) -> CGFloat {
+        let sizeToFit: CGSize
+
+        /// Consider preferredContentSize if it's a view of UIViewController
+        if let viewController = next as? UIViewController {
+            sizeToFit = viewController.preferredContentSize != .zero ? viewController.preferredContentSize : size
+        } else {
+            sizeToFit = size
+        }
+
+        return systemLayoutSizeFitting(
+            sizeToFit,
+            withHorizontalFittingPriority: .required,
+            verticalFittingPriority: .fittingSizeLevel
+        ).height
     }
 }

--- a/Sources/BottomSheetCalculator.swift
+++ b/Sources/BottomSheetCalculator.swift
@@ -143,7 +143,7 @@ extension UIView {
 
         /// Consider preferredContentSize if it's a view of UIViewController
         if let viewController = next as? UIViewController {
-            sizeToFit = viewController.preferredContentSize != .zero ? viewController.preferredContentSize : size
+            sizeToFit = viewController.preferredContentSize
         } else {
             sizeToFit = size
         }

--- a/Sources/BottomSheetNavigationController.swift
+++ b/Sources/BottomSheetNavigationController.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 
-public class BottomSheetNavigationController: UINavigationController {
+open class BottomSheetNavigationController: UINavigationController {
     private var bottomSheetTransitioningDelegate: BottomSheetTransitioningDelegate?
 
     // MARK: - Init
@@ -25,7 +25,7 @@ public class BottomSheetNavigationController: UINavigationController {
 
     // MARK: - View lifecycle
 
-    public override func viewDidLoad() {
+    open override func viewDidLoad() {
         super.viewDidLoad()
         navigationBar.isTranslucent = false
         delegate = self

--- a/Sources/BottomSheetNavigationController.swift
+++ b/Sources/BottomSheetNavigationController.swift
@@ -35,13 +35,8 @@ open class BottomSheetNavigationController: UINavigationController {
 
     public func systemLayoutSizeFittingHeight(for viewController: UIViewController) -> CGFloat {
         let navigationBarHeight = navigationBar.isTranslucent || navigationBar.isHidden ? 0 : navigationBar.frame.size.height
-        let size = viewController.view.systemLayoutSizeFitting(
-            initialViewSize,
-            withHorizontalFittingPriority: .required,
-            verticalFittingPriority: .fittingSizeLevel
-        )
-
-        return size.height + navigationBarHeight
+        let height = viewController.view.systemLayoutHeightFitting(initialViewSize)
+        return height + navigationBarHeight
     }
 
     public func reload(with height: CGFloat) {
@@ -60,43 +55,3 @@ extension BottomSheetNavigationController: UINavigationControllerDelegate {
         reload(with: height)
     }
 }
-
-//// MARK: - Private types
-//
-//private final class WrapperView: UIView {
-//    private let contentView: UIView
-//
-//    init(contentView: UIView) {
-//        self.contentView = contentView
-//        super.init(frame: .zero)
-//        setup()
-//    }
-//
-//    required init?(coder: NSCoder) {
-//        fatalError("init(coder:) has not been implemented")
-//    }
-//
-//    override func systemLayoutSizeFitting(
-//        _ targetSize: CGSize,
-//        withHorizontalFittingPriority horizontalFittingPriority: UILayoutPriority,
-//        verticalFittingPriority: UILayoutPriority
-//    ) -> CGSize {
-//        return contentView.systemLayoutSizeFitting(
-//            targetSize,
-//            withHorizontalFittingPriority: horizontalFittingPriority,
-//            verticalFittingPriority: verticalFittingPriority
-//        )
-//    }
-//
-//    private func setup() {
-//        backgroundColor = contentView.backgroundColor
-//        addSubview(contentView)
-//        contentView.translatesAutoresizingMaskIntoConstraints = false
-//
-//        NSLayoutConstraint.activate([
-//            contentView.topAnchor.constraint(equalTo: topAnchor),
-//            contentView.leadingAnchor.constraint(equalTo: leadingAnchor),
-//            contentView.trailingAnchor.constraint(equalTo: trailingAnchor),
-//        ])
-//    }
-//}

--- a/Sources/BottomSheetNavigationController.swift
+++ b/Sources/BottomSheetNavigationController.swift
@@ -27,7 +27,6 @@ open class BottomSheetNavigationController: UINavigationController {
 
     open override func viewDidLoad() {
         super.viewDidLoad()
-        navigationBar.isTranslucent = false
         delegate = self
     }
 
@@ -45,7 +44,7 @@ open class BottomSheetNavigationController: UINavigationController {
     // MARK: - Public
 
     public func systemLayoutSizeFittingHeight(for viewController: UIViewController) -> CGFloat {
-        let navigationBarHeight = navigationBar.isTranslucent ? 0 : navigationBar.frame.size.height
+        let navigationBarHeight = navigationBar.isTranslucent || navigationBar.isHidden ? 0 : navigationBar.frame.size.height
         let size = viewController.view.systemLayoutSizeFitting(
             view.frame.size,
             withHorizontalFittingPriority: .required,

--- a/Sources/BottomSheetNavigationController.swift
+++ b/Sources/BottomSheetNavigationController.swift
@@ -65,7 +65,7 @@ open class BottomSheetNavigationController: UINavigationController {
 extension BottomSheetNavigationController: UINavigationControllerDelegate {
     public func navigationController(
         _ navigationController: UINavigationController,
-        willShow viewController: UIViewController, animated: Bool
+        didShow viewController: UIViewController, animated: Bool
     ) {
         let height = systemLayoutSizeFittingHeight(for: viewController)
         reload(with: height)

--- a/Sources/BottomSheetNavigationController.swift
+++ b/Sources/BottomSheetNavigationController.swift
@@ -1,0 +1,117 @@
+//
+//  Copyright © FINN.no AS, Inc. All rights reserved.
+//
+
+import UIKit
+
+public class BottomSheetNavigationController: UINavigationController {
+    private let notificationCenter = NotificationCenter.default
+    private var bottomSheetTransitioningDelegate: BottomSheetTransitioningDelegate?
+
+    // MARK: - Init
+
+    public init(rootViewController: UIViewController, notificationCenter: NotificationCenter = .default) {
+        super.init(rootViewController: rootViewController)
+        bottomSheetTransitioningDelegate = BottomSheetTransitioningDelegate(
+            contentHeights: [systemLayoutSizeFittingHeight(for: rootViewController)]
+        )
+        transitioningDelegate = bottomSheetTransitioningDelegate
+        modalPresentationStyle = .custom
+    }
+
+    public required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    deinit {
+        notificationCenter.removeObserver(self)
+    }
+
+    // MARK: - View lifecycle
+
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        navigationBar.isTranslucent = false
+        delegate = self
+    }
+
+    // MARK: - Navigation
+
+    public override func pushViewController(_ viewController: UIViewController, animated: Bool) {
+        if let view = viewController.view {
+            view.removeFromSuperview()
+            viewController.view = WrapperView(contentView: view)
+        }
+
+        super.pushViewController(viewController, animated: animated)
+    }
+
+    // MARK: - Public
+
+    public func systemLayoutSizeFittingHeight(for viewController: UIViewController) -> CGFloat {
+        let navigationBarHeight = navigationBar.isTranslucent ? 0 : navigationBar.frame.size.height
+        let size = viewController.view.systemLayoutSizeFitting(
+            view.frame.size,
+            withHorizontalFittingPriority: .required,
+            verticalFittingPriority: .fittingSizeLevel
+        )
+
+        return size.height + navigationBarHeight
+    }
+
+    public func reload(with height: CGFloat) {
+        bottomSheetTransitioningDelegate?.reload(with: [height])
+    }
+}
+
+// MARK: - UINavigationControllerDelegate
+
+extension BottomSheetNavigationController: UINavigationControllerDelegate {
+    public func navigationController(
+        _ navigationController: UINavigationController,
+        willShow viewController: UIViewController, animated: Bool
+    ) {
+        let height = systemLayoutSizeFittingHeight(for: viewController)
+        reload(with: height)
+    }
+}
+
+// MARK: - Private types
+
+private final class WrapperView: UIView {
+    private let contentView: UIView
+
+    init(contentView: UIView) {
+        self.contentView = contentView
+        super.init(frame: .zero)
+        setup()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func systemLayoutSizeFitting(
+        _ targetSize: CGSize,
+        withHorizontalFittingPriority horizontalFittingPriority: UILayoutPriority,
+        verticalFittingPriority: UILayoutPriority
+    ) -> CGSize {
+        return contentView.systemLayoutSizeFitting(
+            targetSize,
+            withHorizontalFittingPriority: horizontalFittingPriority,
+            verticalFittingPriority: verticalFittingPriority
+        )
+    }
+
+    private func setup() {
+        backgroundColor = contentView.backgroundColor
+        addSubview(contentView)
+        contentView.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            contentView.topAnchor.constraint(equalTo: topAnchor),
+            contentView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            contentView.trailingAnchor.constraint(equalTo: trailingAnchor),
+        ])
+    }
+}

--- a/Sources/BottomSheetNavigationController.swift
+++ b/Sources/BottomSheetNavigationController.swift
@@ -5,15 +5,15 @@
 import UIKit
 
 public class BottomSheetNavigationController: UINavigationController {
-    private let notificationCenter = NotificationCenter.default
     private var bottomSheetTransitioningDelegate: BottomSheetTransitioningDelegate?
 
     // MARK: - Init
 
-    public init(rootViewController: UIViewController, notificationCenter: NotificationCenter = .default) {
+    public init(rootViewController: UIViewController, useSafeAreaInsets: Bool = false) {
         super.init(rootViewController: rootViewController)
         bottomSheetTransitioningDelegate = BottomSheetTransitioningDelegate(
-            contentHeights: [systemLayoutSizeFittingHeight(for: rootViewController)]
+            contentHeights: [systemLayoutSizeFittingHeight(for: rootViewController)],
+            useSafeAreaInsets: useSafeAreaInsets
         )
         transitioningDelegate = bottomSheetTransitioningDelegate
         modalPresentationStyle = .custom
@@ -21,10 +21,6 @@ public class BottomSheetNavigationController: UINavigationController {
 
     public required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-
-    deinit {
-        notificationCenter.removeObserver(self)
     }
 
     // MARK: - View lifecycle

--- a/Sources/BottomSheetNavigationController.swift
+++ b/Sources/BottomSheetNavigationController.swift
@@ -6,6 +6,7 @@ import UIKit
 
 open class BottomSheetNavigationController: UINavigationController {
     private var bottomSheetTransitioningDelegate: BottomSheetTransitioningDelegate?
+    private lazy var initialViewSize = view.frame.size
 
     // MARK: - Init
 
@@ -30,23 +31,12 @@ open class BottomSheetNavigationController: UINavigationController {
         delegate = self
     }
 
-    // MARK: - Navigation
-
-    public override func pushViewController(_ viewController: UIViewController, animated: Bool) {
-        if let view = viewController.view {
-            view.removeFromSuperview()
-            viewController.view = WrapperView(contentView: view)
-        }
-
-        super.pushViewController(viewController, animated: animated)
-    }
-
     // MARK: - Public
 
     public func systemLayoutSizeFittingHeight(for viewController: UIViewController) -> CGFloat {
         let navigationBarHeight = navigationBar.isTranslucent || navigationBar.isHidden ? 0 : navigationBar.frame.size.height
         let size = viewController.view.systemLayoutSizeFitting(
-            view.frame.size,
+            initialViewSize,
             withHorizontalFittingPriority: .required,
             verticalFittingPriority: .fittingSizeLevel
         )
@@ -71,42 +61,42 @@ extension BottomSheetNavigationController: UINavigationControllerDelegate {
     }
 }
 
-// MARK: - Private types
-
-private final class WrapperView: UIView {
-    private let contentView: UIView
-
-    init(contentView: UIView) {
-        self.contentView = contentView
-        super.init(frame: .zero)
-        setup()
-    }
-
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    override func systemLayoutSizeFitting(
-        _ targetSize: CGSize,
-        withHorizontalFittingPriority horizontalFittingPriority: UILayoutPriority,
-        verticalFittingPriority: UILayoutPriority
-    ) -> CGSize {
-        return contentView.systemLayoutSizeFitting(
-            targetSize,
-            withHorizontalFittingPriority: horizontalFittingPriority,
-            verticalFittingPriority: verticalFittingPriority
-        )
-    }
-
-    private func setup() {
-        backgroundColor = contentView.backgroundColor
-        addSubview(contentView)
-        contentView.translatesAutoresizingMaskIntoConstraints = false
-
-        NSLayoutConstraint.activate([
-            contentView.topAnchor.constraint(equalTo: topAnchor),
-            contentView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            contentView.trailingAnchor.constraint(equalTo: trailingAnchor),
-        ])
-    }
-}
+//// MARK: - Private types
+//
+//private final class WrapperView: UIView {
+//    private let contentView: UIView
+//
+//    init(contentView: UIView) {
+//        self.contentView = contentView
+//        super.init(frame: .zero)
+//        setup()
+//    }
+//
+//    required init?(coder: NSCoder) {
+//        fatalError("init(coder:) has not been implemented")
+//    }
+//
+//    override func systemLayoutSizeFitting(
+//        _ targetSize: CGSize,
+//        withHorizontalFittingPriority horizontalFittingPriority: UILayoutPriority,
+//        verticalFittingPriority: UILayoutPriority
+//    ) -> CGSize {
+//        return contentView.systemLayoutSizeFitting(
+//            targetSize,
+//            withHorizontalFittingPriority: horizontalFittingPriority,
+//            verticalFittingPriority: verticalFittingPriority
+//        )
+//    }
+//
+//    private func setup() {
+//        backgroundColor = contentView.backgroundColor
+//        addSubview(contentView)
+//        contentView.translatesAutoresizingMaskIntoConstraints = false
+//
+//        NSLayoutConstraint.activate([
+//            contentView.topAnchor.constraint(equalTo: topAnchor),
+//            contentView.leadingAnchor.constraint(equalTo: leadingAnchor),
+//            contentView.trailingAnchor.constraint(equalTo: trailingAnchor),
+//        ])
+//    }
+//}

--- a/Sources/BottomSheetPresentationController.swift
+++ b/Sources/BottomSheetPresentationController.swift
@@ -125,7 +125,7 @@ extension BottomSheetPresentationController: UIViewControllerAnimatedTransitioni
         self.transitionContext = transitionContext
 
         let completion = { [weak self] (didComplete: Bool) in
-            transitionContext.completeTransition(didComplete)
+            self?.transitionContext?.completeTransition(didComplete)
             self?.transitionState = nil
         }
 

--- a/Sources/BottomSheetPresentationController.swift
+++ b/Sources/BottomSheetPresentationController.swift
@@ -19,7 +19,7 @@ final class BottomSheetPresentationController: UIPresentationController {
 
     // MARK: - Private properties
 
-    private let contentHeights: [CGFloat]
+    private var contentHeights: [CGFloat]
     private let startTargetIndex: Int
     private let useSafeAreaInsets: Bool
     private var dismissVelocity: CGPoint = .zero
@@ -39,6 +39,17 @@ final class BottomSheetPresentationController: UIPresentationController {
         self.startTargetIndex = startTargetIndex
         self.useSafeAreaInsets = useSafeAreaInsets
         super.init(presentedViewController: presentedViewController, presenting: presenting)
+    }
+
+    // MARK: - Internal
+
+    public func reset() {
+        bottomSheetView?.reset()
+    }
+
+    public func reload(with contentHeights: [CGFloat]) {
+        self.contentHeights = contentHeights
+        bottomSheetView?.reload(with: contentHeights)
     }
 
     // MARK: - Transition life cycle

--- a/Sources/BottomSheetTransitioningDelegate.swift
+++ b/Sources/BottomSheetTransitioningDelegate.swift
@@ -5,7 +5,7 @@
 import UIKit
 
 public final class BottomSheetTransitioningDelegate: NSObject {
-    private let contentHeights: [CGFloat]
+    private var contentHeights: [CGFloat]
     private let startTargetIndex: Int
     private let useSafeAreaInsets: Bool
     private var presentationController: BottomSheetPresentationController?
@@ -16,6 +16,17 @@ public final class BottomSheetTransitioningDelegate: NSObject {
         self.contentHeights = contentHeights
         self.startTargetIndex = startTargetIndex
         self.useSafeAreaInsets = useSafeAreaInsets
+    }
+
+    // MARK: - Public
+
+    public func reset() {
+        presentationController?.reset()
+    }
+
+    public func reload(with contentHeights: [CGFloat]) {
+        self.contentHeights = contentHeights
+        presentationController?.reload(with: contentHeights)
     }
 }
 

--- a/Sources/BottomSheetTransitioningDelegate.swift
+++ b/Sources/BottomSheetTransitioningDelegate.swift
@@ -8,7 +8,11 @@ public final class BottomSheetTransitioningDelegate: NSObject {
     private var contentHeights: [CGFloat]
     private let startTargetIndex: Int
     private let useSafeAreaInsets: Bool
-    private var presentationController: BottomSheetPresentationController?
+    private var weakPresentationController: WeakRef<BottomSheetPresentationController>?
+
+    private var presentationController: BottomSheetPresentationController? {
+        return weakPresentationController?.value
+    }
 
     // MARK: - Init
 
@@ -38,13 +42,14 @@ extension BottomSheetTransitioningDelegate: UIViewControllerTransitioningDelegat
         presenting: UIViewController?,
         source: UIViewController
     ) -> UIPresentationController? {
-        presentationController = BottomSheetPresentationController(
+        let presentationController = BottomSheetPresentationController(
             presentedViewController: presented,
             presenting: presenting,
             contentHeights: contentHeights,
             startTargetIndex: startTargetIndex,
             useSafeAreaInsets: useSafeAreaInsets
         )
+        self.weakPresentationController = WeakRef(value: presentationController)
         return presentationController
     }
 
@@ -66,5 +71,15 @@ extension BottomSheetTransitioningDelegate: UIViewControllerTransitioningDelegat
         using animator: UIViewControllerAnimatedTransitioning
     ) -> UIViewControllerInteractiveTransitioning? {
         return presentationController
+    }
+}
+
+// MARK: - Private types
+
+private class WeakRef<T> where T: AnyObject {
+    private(set) weak var value: T?
+
+    init(value: T?) {
+        self.value = value
     }
 }

--- a/Sources/BottomSheetView.swift
+++ b/Sources/BottomSheetView.swift
@@ -33,7 +33,7 @@ public final class BottomSheetView: UIView {
     private let isDismissable: Bool
     private let contentView: UIView
     private var topConstraint: NSLayoutConstraint!
-    private let contentHeights: [CGFloat]
+    private var contentHeights: [CGFloat]
     private var targetOffsets = [CGFloat]()
     private var currentTargetOffsetIndex: Int = 0
 
@@ -177,6 +177,11 @@ public final class BottomSheetView: UIView {
         updateTargetOffsets()
         createTranslationTargets()
         animate(to: targetOffsets[currentTargetOffsetIndex])
+    }
+
+    public func reload(with contentHeights: [CGFloat]) {
+        self.contentHeights = contentHeights
+        reset()
     }
 
     /// Animates bottom sheet view to the given height.

--- a/Sources/BottomSheetView.swift
+++ b/Sources/BottomSheetView.swift
@@ -128,8 +128,8 @@ public final class BottomSheetView: UIView {
         }
 
         springAnimator.addAnimation { [weak self] position in
-            self?.topConstraint.constant = position.y
             self?.updateDimViewAlpha(for: position.y)
+            self?.topConstraint.constant = position.y
         }
 
         springAnimator.addCompletion { didComplete in completion?(didComplete) }
@@ -250,6 +250,10 @@ public final class BottomSheetView: UIView {
     }
 
     private func updateDimViewAlpha(for offset: CGFloat) {
+        if offset <= topConstraint.constant && dimView.alpha == 1 {
+            return
+        }
+
         if let superview = superview, let maxOffset = targetOffsets.max() {
             dimView.alpha = min(1, (superview.frame.height - offset) / (superview.frame.height - maxOffset))
         }

--- a/Sources/BottomSheetView.swift
+++ b/Sources/BottomSheetView.swift
@@ -66,6 +66,8 @@ public final class BottomSheetView: UIView {
         return view
     }()
 
+    private lazy var contentViewHeightConstraint = contentView.heightAnchor.constraint(greaterThanOrEqualToConstant: 0)
+
     // MARK: - Init
 
     public init(
@@ -132,22 +134,15 @@ public final class BottomSheetView: UIView {
 
         springAnimator.addCompletion { didComplete in completion?(didComplete) }
 
-        var constraints: [NSLayoutConstraint] = [
+        NSLayoutConstraint.activate([
             topConstraint,
             bottomAnchor.constraint(greaterThanOrEqualTo: superview.bottomAnchor),
             leadingAnchor.constraint(equalTo: superview.leadingAnchor),
-            trailingAnchor.constraint(equalTo: superview.trailingAnchor)
-        ]
+            trailingAnchor.constraint(equalTo: superview.trailingAnchor),
+            contentViewHeightConstraint
+        ])
 
         updateTargetOffsets()
-
-        if let maxOffset = targetOffsets.max() {
-            let contentViewHeight = superview.frame.size.height - maxOffset - .handleHeight - bottomInset
-            constraints.append(contentView.heightAnchor.constraint(greaterThanOrEqualToConstant: contentViewHeight))
-        }
-
-        NSLayoutConstraint.activate(constraints)
-        superview.layoutIfNeeded()
         addGestureRecognizer(panGesture)
 
         transition(to: targetIndex)
@@ -313,6 +308,13 @@ public final class BottomSheetView: UIView {
         targetOffsets = contentHeights.map {
             BottomSheetCalculator.offset(for: contentView, in: superview, height: $0, useSafeAreaInsets: useSafeAreaInsets)
         }.sorted(by: >)
+
+        if let maxOffset = targetOffsets.max() {
+            let contentViewHeight = superview.frame.size.height - maxOffset - .handleHeight - bottomInset
+            contentViewHeightConstraint.constant = contentViewHeight
+        }
+
+        superview.layoutIfNeeded()
     }
 
     private func createTranslationTargets() {


### PR DESCRIPTION
# Why?

It seems to be a common scenario to present `UINavigationController` within the bottom sheet. This PR aims to address the challenge of adjusting the height for every pushed view controller.

# What?

- Add `BottomSheetNavigationController`, which creates and manages its own instance of `BottomSheetTransitioningDelegate` to change automatic height when a new view controller is pushed onto the navigation stack. Even though we wanted to avoid "BottomSheet" view controllers in our new implementation, I think it's better to have this specialized class than make `BottomSheetPresentationController` aware of its `presentedViewController` type and treat navigation controllers in a different way. Setting `modalPresentationStyle` of `BottomSheetNavigationController` to something else than `custom` would make it a regular navigation controller, which would work fine for iPad support.

- Fix strong reference cycle we had in `BottomSheetTransitioningDelegate`.

- Update dim view alpha only when it's necessary

# Show me

![bs_nav](https://user-images.githubusercontent.com/10529867/71247730-a05faa00-2319-11ea-9ae2-c2c8b50a2a42.gif)