### PR TITLE
Make transitioning delegate and bottom sheet view more customisable

### DIFF
--- a/Sources/BottomSheetPresentationController.swift
+++ b/Sources/BottomSheetPresentationController.swift
@@ -43,11 +43,15 @@ final class BottomSheetPresentationController: UIPresentationController {
 
     // MARK: - Internal
 
-    public func reset() {
+    func transition(to index: Int) {
+        bottomSheetView?.transition(to: index)
+    }
+
+    func reset() {
         bottomSheetView?.reset()
     }
 
-    public func reload(with contentHeights: [CGFloat]) {
+    func reload(with contentHeights: [CGFloat]) {
         self.contentHeights = contentHeights
         bottomSheetView?.reload(with: contentHeights)
     }

--- a/Sources/BottomSheetPresentationController.swift
+++ b/Sources/BottomSheetPresentationController.swift
@@ -21,6 +21,7 @@ final class BottomSheetPresentationController: UIPresentationController {
 
     private var contentHeights: [CGFloat]
     private let startTargetIndex: Int
+    private let handleBackground: BottomSheetView.HandleBackground
     private let useSafeAreaInsets: Bool
     private var dismissVelocity: CGPoint = .zero
     private var bottomSheetView: BottomSheetView?
@@ -33,10 +34,12 @@ final class BottomSheetPresentationController: UIPresentationController {
         presenting: UIViewController?,
         contentHeights: [CGFloat],
         startTargetIndex: Int,
+        handleBackground: BottomSheetView.HandleBackground,
         useSafeAreaInsets: Bool
     ) {
         self.contentHeights = contentHeights
         self.startTargetIndex = startTargetIndex
+        self.handleBackground = handleBackground
         self.useSafeAreaInsets = useSafeAreaInsets
         super.init(presentedViewController: presentedViewController, presenting: presenting)
     }
@@ -104,6 +107,7 @@ final class BottomSheetPresentationController: UIPresentationController {
         bottomSheetView = BottomSheetView(
             contentView: presentedView,
             contentHeights: contentHeights,
+            handleBackground: handleBackground,
             useSafeAreaInsets: useSafeAreaInsets,
             isDismissible: true
         )

--- a/Sources/BottomSheetPresentationController.swift
+++ b/Sources/BottomSheetPresentationController.swift
@@ -25,6 +25,7 @@ final class BottomSheetPresentationController: UIPresentationController {
     private let useSafeAreaInsets: Bool
     private var dismissVelocity: CGPoint = .zero
     private var bottomSheetView: BottomSheetView?
+    private weak var animationDelegate: BottomSheetViewAnimationDelegate?
     private weak var transitionContext: UIViewControllerContextTransitioning?
 
     // MARK: - Init
@@ -34,12 +35,14 @@ final class BottomSheetPresentationController: UIPresentationController {
         presenting: UIViewController?,
         contentHeights: [CGFloat],
         startTargetIndex: Int,
+        animationDelegate: BottomSheetViewAnimationDelegate?,
         handleBackground: BottomSheetView.HandleBackground,
         useSafeAreaInsets: Bool
     ) {
         self.contentHeights = contentHeights
         self.startTargetIndex = startTargetIndex
         self.handleBackground = handleBackground
+        self.animationDelegate = animationDelegate
         self.useSafeAreaInsets = useSafeAreaInsets
         super.init(presentedViewController: presentedViewController, presenting: presenting)
     }
@@ -112,6 +115,7 @@ final class BottomSheetPresentationController: UIPresentationController {
             isDismissible: true
         )
 
+        bottomSheetView?.animationDelegate = animationDelegate
         bottomSheetView?.delegate = self
         bottomSheetView?.isDimViewHidden = false
     }

--- a/Sources/BottomSheetTransitioningDelegate.swift
+++ b/Sources/BottomSheetTransitioningDelegate.swift
@@ -24,6 +24,16 @@ public final class BottomSheetTransitioningDelegate: NSObject {
 
     // MARK: - Public
 
+    /// Animates bottom sheet view to the given height.
+    ///
+    /// - Parameters:
+    ///   - index: the index of the target height
+    public func transition(to index: Int) {
+        presentationController?.transition(to: index)
+    }
+
+    /// Recalculates target offsets and animates to the minimum one.
+    /// Call this method e.g. when orientation change is detected.
     public func reset() {
         presentationController?.reset()
     }

--- a/Sources/BottomSheetTransitioningDelegate.swift
+++ b/Sources/BottomSheetTransitioningDelegate.swift
@@ -10,6 +10,7 @@ public final class BottomSheetTransitioningDelegate: NSObject {
     private let handleBackground: BottomSheetView.HandleBackground
     private let useSafeAreaInsets: Bool
     private var weakPresentationController: WeakRef<BottomSheetPresentationController>?
+    private weak var animationDelegate: BottomSheetViewAnimationDelegate?
 
     private var presentationController: BottomSheetPresentationController? {
         return weakPresentationController?.value
@@ -21,11 +22,13 @@ public final class BottomSheetTransitioningDelegate: NSObject {
         contentHeights: [CGFloat],
         startTargetIndex: Int = 0,
         handleBackground: BottomSheetView.HandleBackground = .color(.clear),
+        animationDelegate: BottomSheetViewAnimationDelegate? = nil,
         useSafeAreaInsets: Bool = false
     ) {
         self.contentHeights = contentHeights
         self.startTargetIndex = startTargetIndex
         self.handleBackground = handleBackground
+        self.animationDelegate = animationDelegate
         self.useSafeAreaInsets = useSafeAreaInsets
     }
 
@@ -64,6 +67,7 @@ extension BottomSheetTransitioningDelegate: UIViewControllerTransitioningDelegat
             presenting: presenting,
             contentHeights: contentHeights,
             startTargetIndex: startTargetIndex,
+            animationDelegate: animationDelegate,
             handleBackground: handleBackground,
             useSafeAreaInsets: useSafeAreaInsets
         )

--- a/Sources/BottomSheetTransitioningDelegate.swift
+++ b/Sources/BottomSheetTransitioningDelegate.swift
@@ -7,6 +7,7 @@ import UIKit
 public final class BottomSheetTransitioningDelegate: NSObject {
     public private(set) var contentHeights: [CGFloat]
     private let startTargetIndex: Int
+    private let handleBackground: BottomSheetView.HandleBackground
     private let useSafeAreaInsets: Bool
     private var weakPresentationController: WeakRef<BottomSheetPresentationController>?
 
@@ -16,9 +17,15 @@ public final class BottomSheetTransitioningDelegate: NSObject {
 
     // MARK: - Init
 
-    public init(contentHeights: [CGFloat], startTargetIndex: Int = 0, useSafeAreaInsets: Bool = false) {
+    public init(
+        contentHeights: [CGFloat],
+        startTargetIndex: Int = 0,
+        handleBackground: BottomSheetView.HandleBackground = .color(.clear),
+        useSafeAreaInsets: Bool = false
+    ) {
         self.contentHeights = contentHeights
         self.startTargetIndex = startTargetIndex
+        self.handleBackground = handleBackground
         self.useSafeAreaInsets = useSafeAreaInsets
     }
 
@@ -57,6 +64,7 @@ extension BottomSheetTransitioningDelegate: UIViewControllerTransitioningDelegat
             presenting: presenting,
             contentHeights: contentHeights,
             startTargetIndex: startTargetIndex,
+            handleBackground: handleBackground,
             useSafeAreaInsets: useSafeAreaInsets
         )
         self.weakPresentationController = WeakRef(value: presentationController)

--- a/Sources/BottomSheetTransitioningDelegate.swift
+++ b/Sources/BottomSheetTransitioningDelegate.swift
@@ -5,7 +5,7 @@
 import UIKit
 
 public final class BottomSheetTransitioningDelegate: NSObject {
-    private var contentHeights: [CGFloat]
+    public private(set) var contentHeights: [CGFloat]
     private let startTargetIndex: Int
     private let useSafeAreaInsets: Bool
     private var weakPresentationController: WeakRef<BottomSheetPresentationController>?

--- a/Sources/BottomSheetView.swift
+++ b/Sources/BottomSheetView.swift
@@ -252,10 +252,13 @@ public final class BottomSheetView: UIView {
         layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
 
         let handleBackgroundView = handleBackground.view
+        handleBackgroundView.layer.cornerRadius = layer.cornerRadius
+        handleBackgroundView.layer.maskedCorners = layer.maskedCorners
+        handleBackgroundView.clipsToBounds = true
 
         addSubview(contentView)
-        addSubview(handleView)
         addSubview(handleBackgroundView)
+        addSubview(handleView)
 
         handleBackgroundView.translatesAutoresizingMaskIntoConstraints = false
         contentView.translatesAutoresizingMaskIntoConstraints = false

--- a/Sources/BottomSheetView.swift
+++ b/Sources/BottomSheetView.swift
@@ -34,6 +34,22 @@ public protocol BottomSheetViewDelegate: AnyObject {
 // MARK: - View
 
 public final class BottomSheetView: UIView {
+    public enum HandleBackground {
+        case color(UIColor)
+        case visualEffect(UIVisualEffect)
+
+        var view: UIView {
+            switch self {
+            case .color(let value):
+                let view = UIView()
+                view.backgroundColor = value
+                return view
+            case .visualEffect(let value):
+                return UIVisualEffectView(effect: value)
+            }
+        }
+    }
+
     public weak var delegate: BottomSheetViewDelegate?
     public private(set) var contentHeights: [CGFloat]
 
@@ -47,6 +63,7 @@ public final class BottomSheetView: UIView {
     private let useSafeAreaInsets: Bool
     private let isDismissable: Bool
     private let contentView: UIView
+    private let handleBackground: HandleBackground
     private var topConstraint: NSLayoutConstraint!
     private var targetOffsets = [CGFloat]()
     private var currentTargetOffsetIndex: Int = 0
@@ -87,10 +104,12 @@ public final class BottomSheetView: UIView {
     public init(
         contentView: UIView,
         contentHeights: [CGFloat],
+        handleBackground: HandleBackground = .color(.clear),
         useSafeAreaInsets: Bool = false,
         isDismissible: Bool = false
     ) {
         self.contentView = contentView
+        self.handleBackground = handleBackground
         self.contentHeights = contentHeights.isEmpty ? [.bottomSheetAutomatic] : contentHeights
         self.useSafeAreaInsets = useSafeAreaInsets
         self.isDismissable = isDismissible
@@ -232,12 +251,21 @@ public final class BottomSheetView: UIView {
         layer.cornerRadius = 16
         layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
 
+        let handleBackgroundView = handleBackground.view
+
         addSubview(contentView)
         addSubview(handleView)
+        addSubview(handleBackgroundView)
 
+        handleBackgroundView.translatesAutoresizingMaskIntoConstraints = false
         contentView.translatesAutoresizingMaskIntoConstraints = false
 
         NSLayoutConstraint.activate([
+            handleBackgroundView.topAnchor.constraint(equalTo: topAnchor),
+            handleBackgroundView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            handleBackgroundView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            handleBackgroundView.heightAnchor.constraint(equalToConstant: .handleHeight),
+
             handleView.topAnchor.constraint(equalTo: topAnchor, constant: 8),
             handleView.centerXAnchor.constraint(equalTo: centerXAnchor),
             handleView.widthAnchor.constraint(equalToConstant: 25),

--- a/Sources/BottomSheetView.swift
+++ b/Sources/BottomSheetView.swift
@@ -10,6 +10,20 @@ extension CGFloat {
     public static let bottomSheetAutomatic: CGFloat = -123456789
 }
 
+extension Array where Element == CGFloat {
+    public static var bottomSheetDefault: [CGFloat] {
+        let screenSize = UIScreen.main.bounds.size
+
+        if screenSize.height <= 568 {
+            return [510, 510]
+        } else if screenSize.height >= 812 {
+            return [570, screenSize.height - 64]
+        } else {
+            return [510, screenSize.height - 64]
+        }
+    }
+}
+
 // MARK: - Delegate
 
 public protocol BottomSheetViewDelegate: AnyObject {

--- a/Sources/BottomSheetView.swift
+++ b/Sources/BottomSheetView.swift
@@ -15,7 +15,7 @@ extension Array where Element == CGFloat {
         let screenSize = UIScreen.main.bounds.size
 
         if screenSize.height <= 568 {
-            return [510, 510]
+            return [510]
         } else if screenSize.height >= 812 {
             return [570, screenSize.height - 64]
         } else {

--- a/Sources/BottomSheetView.swift
+++ b/Sources/BottomSheetView.swift
@@ -33,6 +33,7 @@ public protocol BottomSheetViewDelegate: AnyObject {
 
 public protocol BottomSheetViewAnimationDelegate: AnyObject {
     func bottomSheetView(_ view: BottomSheetView, didAnimateToPosition position: CGPoint)
+    func bottomSheetView(_ view: BottomSheetView, didCompleteAnimation complete: Bool)
 }
 
 // MARK: - View
@@ -172,7 +173,11 @@ public final class BottomSheetView: UIView {
             self.animationDelegate?.bottomSheetView(self, didAnimateToPosition: position)
         }
 
-        springAnimator.addCompletion { didComplete in completion?(didComplete) }
+        springAnimator.addCompletion { [weak self] didComplete in
+            guard let self = self else { return }
+            completion?(didComplete)
+            self.animationDelegate?.bottomSheetView(self, didCompleteAnimation: didComplete)
+        }
 
         NSLayoutConstraint.activate([
             topConstraint,

--- a/Sources/BottomSheetView.swift
+++ b/Sources/BottomSheetView.swift
@@ -31,6 +31,10 @@ public protocol BottomSheetViewDelegate: AnyObject {
     func bottomSheetViewDidReachDismissArea(_ view: BottomSheetView, with velocity: CGPoint)
 }
 
+public protocol BottomSheetViewAnimationDelegate: AnyObject {
+    func bottomSheetView(_ view: BottomSheetView, didAnimateToPosition position: CGPoint)
+}
+
 // MARK: - View
 
 public final class BottomSheetView: UIView {
@@ -51,6 +55,7 @@ public final class BottomSheetView: UIView {
     }
 
     public weak var delegate: BottomSheetViewDelegate?
+    public weak var animationDelegate: BottomSheetViewAnimationDelegate?
     public private(set) var contentHeights: [CGFloat]
 
     public var isDimViewHidden: Bool {
@@ -161,8 +166,10 @@ public final class BottomSheetView: UIView {
         }
 
         springAnimator.addAnimation { [weak self] position in
-            self?.updateDimViewAlpha(for: position.y)
-            self?.topConstraint.constant = position.y
+            guard let self = self else { return }
+            self.updateDimViewAlpha(for: position.y)
+            self.topConstraint.constant = position.y
+            self.animationDelegate?.bottomSheetView(self, didAnimateToPosition: position)
         }
 
         springAnimator.addCompletion { didComplete in completion?(didComplete) }

--- a/Sources/BottomSheetView.swift
+++ b/Sources/BottomSheetView.swift
@@ -35,6 +35,7 @@ public protocol BottomSheetViewDelegate: AnyObject {
 
 public final class BottomSheetView: UIView {
     public weak var delegate: BottomSheetViewDelegate?
+    public private(set) var contentHeights: [CGFloat]
 
     public var isDimViewHidden: Bool {
         get { dimView.isHidden }
@@ -47,7 +48,6 @@ public final class BottomSheetView: UIView {
     private let isDismissable: Bool
     private let contentView: UIView
     private var topConstraint: NSLayoutConstraint!
-    private var contentHeights: [CGFloat]
     private var targetOffsets = [CGFloat]()
     private var currentTargetOffsetIndex: Int = 0
 


### PR DESCRIPTION
# Why?

We forgot to add `transition:to` method to `BottomSheetTransitioningDelegate`.

# What?

- Add `transition:to` method to `BottomSheetTransitioningDelegate`
- Add an array of default content heights as `bottomSheetDefault` property in `[CGFloat]` extension. This might be useful for cases when we want to set the same compact/expanded heights as for the old implementation of the bottom sheet, e.g. in `Charcoal`.
- Make `contentHeights` publicly accessible
- Make it possible to set handle background to either color or visual effect view because we need that in the app
- Add `BottomSheetViewAnimationDelegate` to observe position changes

# Show me

No UI changes.