### PR TITLE
Introduce dismissal delegate

### DIFF
--- a/Demo/DemoViewController.swift
+++ b/Demo/DemoViewController.swift
@@ -8,7 +8,7 @@ import BottomSheet
 final class DemoViewController: UIViewController {
     private lazy var bottomSheetTransitioningDelegate = BottomSheetTransitioningDelegate(
         contentHeights: [.bottomSheetAutomatic, UIScreen.main.bounds.size.height - 200],
-        dismissalDelegate: self
+        presentationDelegate: self
     )
 
     // MARK: - Lifecycle
@@ -82,17 +82,33 @@ final class DemoViewController: UIViewController {
 
 // MARK: - BottomSheetViewDismissalDelegate
 
-extension DemoViewController: BottomSheetViewDismissalDelegate {
-    func bottomSheetViewCanDismissByGesture(_ view: BottomSheetView) -> Bool {
+extension DemoViewController: BottomSheetPresentationControllerDelegate {
+    func bottomSheetPresentationController(
+        _ controller: UIPresentationController,
+        shouldDismissBy action: BottomSheetView.DismissAction
+    ) -> Bool {
         return true
     }
 
-    func bottomSheetViewDidTapDimView(_ view: BottomSheetView) {
-        print("Did tap dim view")
+    func bottomSheetPresentationController(
+        _ controller: UIPresentationController,
+        didCancelDismissBy action: BottomSheetView.DismissAction
+    ) {
+        print("Did cancel dismiss by \(action)")
     }
 
-    func bottomSheetViewDidReachDismissArea(_ view: BottomSheetView, with velocity: CGPoint) {
-        print("Did rearch dismiss area")
+    func bottomSheetPresentationController(
+        _ controller: UIPresentationController,
+        willDismissBy action: BottomSheetView.DismissAction?
+    ) {
+        print("Will dismiss dismiss by \(String(describing: action))")
+    }
+
+    func bottomSheetPresentationController(
+        _ controller: UIPresentationController,
+        didDismissBy action: BottomSheetView.DismissAction?
+    ) {
+        print("Did dismiss dismiss by \(String(describing: action))")
     }
 }
 

--- a/Demo/DemoViewController.swift
+++ b/Demo/DemoViewController.swift
@@ -83,7 +83,7 @@ final class DemoViewController: UIViewController {
 // MARK: - BottomSheetViewDismissalDelegate
 
 extension DemoViewController: BottomSheetViewDismissalDelegate {
-    func bottomSheetViewCanDismiss(_ view: BottomSheetView) -> Bool {
+    func bottomSheetViewCanDismissByGesture(_ view: BottomSheetView) -> Bool {
         return true
     }
 

--- a/Demo/DemoViewController.swift
+++ b/Demo/DemoViewController.swift
@@ -7,7 +7,8 @@ import BottomSheet
 
 final class DemoViewController: UIViewController {
     private lazy var bottomSheetTransitioningDelegate = BottomSheetTransitioningDelegate(
-        contentHeights: [.bottomSheetAutomatic, UIScreen.main.bounds.size.height - 200]
+        contentHeights: [.bottomSheetAutomatic, UIScreen.main.bounds.size.height - 200],
+        dismissalDelegate: self
     )
 
     // MARK: - Lifecycle
@@ -76,6 +77,22 @@ final class DemoViewController: UIViewController {
             contentHeights: [100, 500]
         )
         bottomSheetView.present(in: view)
+    }
+}
+
+// MARK: - BottomSheetViewDismissalDelegate
+
+extension DemoViewController: BottomSheetViewDismissalDelegate {
+    func bottomSheetViewCanDismiss(_ view: BottomSheetView) -> Bool {
+        return true
+    }
+
+    func bottomSheetViewDidTapDimView(_ view: BottomSheetView) {
+        print("Did tap dim view")
+    }
+
+    func bottomSheetViewDidReachDismissArea(_ view: BottomSheetView, with velocity: CGPoint) {
+        print("Did rearch dismiss area")
     }
 }
 

--- a/Sources/BottomSheetCalculator.swift
+++ b/Sources/BottomSheetCalculator.swift
@@ -59,12 +59,12 @@ struct BottomSheetCalculator {
     ///   - targetOffsets: array containing the different target offsets a BottomSheetView can transition between
     ///   - currentTargetIndex: index of the current target offset of the BottomSheetView
     ///   - superview: the bottom sheet container view
-    ///   - isDismissable: flag specifying whether the last translation target should dismiss the BottomSheetView
+    ///   - targetMaxHeight: flag specifying whether the last translation target should dismiss the BottomSheetView
     static func createTranslationTargets(
         for targetOffsets: [CGFloat],
         at currentTargetIndex: Int,
         in superview: UIView,
-        isDismissible: Bool
+        targetMaxHeight: Bool
     ) -> [TranslationTarget] {
         guard !targetOffsets.isEmpty else { return [] }
 
@@ -79,7 +79,7 @@ struct BottomSheetCalculator {
         }
         // If the BottomSheetView is dismissible we want the user to translate a certain amount before transitioning to the dismiss translation target
         // If not, make it stop at the smallest target height by setting the first threshold to zero.
-        let lowestThreshold = isDismissible ? threshold(superview.frame.height, maxOffset) : 0
+        let lowestThreshold = targetMaxHeight ? threshold(superview.frame.height, maxOffset) : 0
         // We add a zero threshold at the end to make the BottomSheetView stop at its biggest height.
         let highestThreshold: CGFloat = 0
         // Calculate all the offsets in between
@@ -99,9 +99,9 @@ struct BottomSheetCalculator {
 
         // Target used to control offsets bigger than or equal to maxOffset
         let bottomTarget = LimitTarget(
-            targetOffset: isDismissible ? superview.frame.height : maxOffset,
+            targetOffset: targetMaxHeight ? superview.frame.height : maxOffset,
             bound: bounds.first ?? maxOffset,
-            behavior: isDismissible ? .linear : .rubberBand(radius: threshold(0, maxOffset)),
+            behavior: targetMaxHeight ? .linear : .rubberBand(radius: threshold(0, maxOffset)),
             isBottomTarget: true,
             compare: >=
         )

--- a/Sources/BottomSheetCalculator.swift
+++ b/Sources/BottomSheetCalculator.swift
@@ -102,7 +102,7 @@ struct BottomSheetCalculator {
             targetOffset: isDismissible ? superview.frame.height : maxOffset,
             bound: bounds.first ?? maxOffset,
             behavior: isDismissible ? .linear : .rubberBand(radius: threshold(0, maxOffset)),
-            isDismissible: isDismissible,
+            isDismissible: true,
             compare: >=
         )
 

--- a/Sources/BottomSheetCalculator.swift
+++ b/Sources/BottomSheetCalculator.swift
@@ -102,7 +102,7 @@ struct BottomSheetCalculator {
             targetOffset: isDismissible ? superview.frame.height : maxOffset,
             bound: bounds.first ?? maxOffset,
             behavior: isDismissible ? .linear : .rubberBand(radius: threshold(0, maxOffset)),
-            isDismissible: true,
+            isBottomTarget: true,
             compare: >=
         )
 
@@ -113,7 +113,7 @@ struct BottomSheetCalculator {
             let target = RangeTarget(
                 targetOffset: targetOffset,
                 range: lowerBound ..< upperBound,
-                isDismissible: false
+                isBottomTarget: false
             )
 
             targets.append(target)
@@ -125,7 +125,7 @@ struct BottomSheetCalculator {
             targetOffset: minOffset,
             bound: minOffset,
             behavior: .rubberBand(radius: threshold(0, minOffset)),
-            isDismissible: false,
+            isBottomTarget: false,
             compare: <
         )
 

--- a/Sources/BottomSheetPresentationController.swift
+++ b/Sources/BottomSheetPresentationController.swift
@@ -206,7 +206,7 @@ extension BottomSheetPresentationController: UIViewControllerInteractiveTransiti
 extension BottomSheetPresentationController: BottomSheetViewDismissalDelegate {
     func bottomSheetView(_ view: BottomSheetView, willDismissBy action: BottomSheetView.DismissAction) {
         guard presentationDelegate?.bottomSheetPresentationController(self, shouldDismissBy: action) ?? true else {
-            //view.reset()
+            view.reset()
             presentationDelegate?.bottomSheetPresentationController(self, didCancelDismissBy: action)
             return
         }

--- a/Sources/BottomSheetPresentationController.swift
+++ b/Sources/BottomSheetPresentationController.swift
@@ -116,7 +116,7 @@ final class BottomSheetPresentationController: UIPresentationController {
         )
 
         bottomSheetView?.animationDelegate = animationDelegate
-        bottomSheetView?.delegate = self
+        bottomSheetView?.actionDelegate = self
         bottomSheetView?.isDimViewHidden = false
     }
 
@@ -170,7 +170,7 @@ extension BottomSheetPresentationController: UIViewControllerInteractiveTransiti
 
 // MARK: - BottomSheetViewPresenterDelegate
 
-extension BottomSheetPresentationController: BottomSheetViewDelegate {
+extension BottomSheetPresentationController: BottomSheetViewActionDelegate {
     func bottomSheetViewDidTapDimView(_ view: BottomSheetView) {
         dismiss(with: .zero)
     }

--- a/Sources/BottomSheetPresentationController.swift
+++ b/Sources/BottomSheetPresentationController.swift
@@ -173,8 +173,8 @@ extension BottomSheetPresentationController: UIViewControllerInteractiveTransiti
 // MARK: - BottomSheetViewPresenterDelegate
 
 extension BottomSheetPresentationController: BottomSheetViewDismissalDelegate {
-    func bottomSheetViewCanDismiss(_ view: BottomSheetView) -> Bool {
-        dismissalDelegate?.bottomSheetViewCanDismiss(view) ?? true
+    func bottomSheetViewCanDismissWithGesture(_ view: BottomSheetView) -> Bool {
+        dismissalDelegate?.bottomSheetViewCanDismissWithGesture(view) ?? true
     }
 
     func bottomSheetViewDidTapDimView(_ view: BottomSheetView) {
@@ -188,7 +188,7 @@ extension BottomSheetPresentationController: BottomSheetViewDismissalDelegate {
     }
 
     private func dismiss(_ view: BottomSheetView, with velocity: CGPoint) {
-        guard dismissalDelegate?.bottomSheetViewCanDismiss(view) ?? true else {
+        guard dismissalDelegate?.bottomSheetViewCanDismissWithGesture(view) ?? true else {
             return
         }
 

--- a/Sources/BottomSheetPresentationController.swift
+++ b/Sources/BottomSheetPresentationController.swift
@@ -206,6 +206,7 @@ extension BottomSheetPresentationController: UIViewControllerInteractiveTransiti
 extension BottomSheetPresentationController: BottomSheetViewDismissalDelegate {
     func bottomSheetView(_ view: BottomSheetView, willDismissBy action: BottomSheetView.DismissAction) {
         guard presentationDelegate?.bottomSheetPresentationController(self, shouldDismissBy: action) ?? true else {
+            //view.reset()
             presentationDelegate?.bottomSheetPresentationController(self, didCancelDismissBy: action)
             return
         }

--- a/Sources/BottomSheetTransitioningDelegate.swift
+++ b/Sources/BottomSheetTransitioningDelegate.swift
@@ -10,6 +10,7 @@ public final class BottomSheetTransitioningDelegate: NSObject {
     private let handleBackground: BottomSheetView.HandleBackground
     private let useSafeAreaInsets: Bool
     private var weakPresentationController: WeakRef<BottomSheetPresentationController>?
+    private weak var dismissalDelegate: BottomSheetViewDismissalDelegate?
     private weak var animationDelegate: BottomSheetViewAnimationDelegate?
 
     private var presentationController: BottomSheetPresentationController? {
@@ -22,12 +23,14 @@ public final class BottomSheetTransitioningDelegate: NSObject {
         contentHeights: [CGFloat],
         startTargetIndex: Int = 0,
         handleBackground: BottomSheetView.HandleBackground = .color(.clear),
+        dismissalDelegate: BottomSheetViewDismissalDelegate? = nil,
         animationDelegate: BottomSheetViewAnimationDelegate? = nil,
         useSafeAreaInsets: Bool = false
     ) {
         self.contentHeights = contentHeights
         self.startTargetIndex = startTargetIndex
         self.handleBackground = handleBackground
+        self.dismissalDelegate = dismissalDelegate
         self.animationDelegate = animationDelegate
         self.useSafeAreaInsets = useSafeAreaInsets
     }
@@ -67,6 +70,7 @@ extension BottomSheetTransitioningDelegate: UIViewControllerTransitioningDelegat
             presenting: presenting,
             contentHeights: contentHeights,
             startTargetIndex: startTargetIndex,
+            dismissalDelegate: dismissalDelegate,
             animationDelegate: animationDelegate,
             handleBackground: handleBackground,
             useSafeAreaInsets: useSafeAreaInsets

--- a/Sources/BottomSheetTransitioningDelegate.swift
+++ b/Sources/BottomSheetTransitioningDelegate.swift
@@ -10,7 +10,7 @@ public final class BottomSheetTransitioningDelegate: NSObject {
     private let handleBackground: BottomSheetView.HandleBackground
     private let useSafeAreaInsets: Bool
     private var weakPresentationController: WeakRef<BottomSheetPresentationController>?
-    private weak var dismissalDelegate: BottomSheetViewDismissalDelegate?
+    private weak var presentationDelegate: BottomSheetPresentationControllerDelegate?
     private weak var animationDelegate: BottomSheetViewAnimationDelegate?
 
     private var presentationController: BottomSheetPresentationController? {
@@ -23,14 +23,14 @@ public final class BottomSheetTransitioningDelegate: NSObject {
         contentHeights: [CGFloat],
         startTargetIndex: Int = 0,
         handleBackground: BottomSheetView.HandleBackground = .color(.clear),
-        dismissalDelegate: BottomSheetViewDismissalDelegate? = nil,
+        presentationDelegate: BottomSheetPresentationControllerDelegate? = nil,
         animationDelegate: BottomSheetViewAnimationDelegate? = nil,
         useSafeAreaInsets: Bool = false
     ) {
         self.contentHeights = contentHeights
         self.startTargetIndex = startTargetIndex
         self.handleBackground = handleBackground
-        self.dismissalDelegate = dismissalDelegate
+        self.presentationDelegate = presentationDelegate
         self.animationDelegate = animationDelegate
         self.useSafeAreaInsets = useSafeAreaInsets
     }
@@ -70,7 +70,7 @@ extension BottomSheetTransitioningDelegate: UIViewControllerTransitioningDelegat
             presenting: presenting,
             contentHeights: contentHeights,
             startTargetIndex: startTargetIndex,
-            dismissalDelegate: dismissalDelegate,
+            presentationDelegate: presentationDelegate,
             animationDelegate: animationDelegate,
             handleBackground: handleBackground,
             useSafeAreaInsets: useSafeAreaInsets

--- a/Sources/BottomSheetView.swift
+++ b/Sources/BottomSheetView.swift
@@ -68,6 +68,10 @@ public final class BottomSheetView: UIView {
         set { dimView.isHidden = newValue }
     }
 
+    // MARK: - Internal properties
+
+    
+
     // MARK: - Private properties
 
     private let useSafeAreaInsets: Bool
@@ -354,7 +358,7 @@ public final class BottomSheetView: UIView {
             }
 
             // if it's the bottom limit target
-            if translationTarget.isDismissible {
+            if translationTarget.isBottomTarget {
                 if let dismissalDelegate = dismissalDelegate {
                     dismissalDelegate.bottomSheetView(self, willDismissBy: .drag(velocity: velocity))
                 } else {

--- a/Sources/BottomSheetView.swift
+++ b/Sources/BottomSheetView.swift
@@ -399,7 +399,7 @@ public final class BottomSheetView: UIView {
             for: targetOffsets,
             at: currentTargetOffsetIndex,
             in: superview,
-            isDismissible: dismissalDelegate != nil
+            targetMaxHeight: dismissalDelegate != nil
         )
     }
 }

--- a/Sources/BottomSheetView.swift
+++ b/Sources/BottomSheetView.swift
@@ -27,7 +27,7 @@ extension Array where Element == CGFloat {
 // MARK: - Delegate
 
 public protocol BottomSheetViewDismissalDelegate: AnyObject {
-    func bottomSheetViewCanDismiss(_ view: BottomSheetView) -> Bool
+    func bottomSheetViewCanDismissWithGesture(_ view: BottomSheetView) -> Bool
     func bottomSheetViewDidTapDimView(_ view: BottomSheetView)
     func bottomSheetViewDidReachDismissArea(_ view: BottomSheetView, with velocity: CGPoint)
 }
@@ -86,7 +86,7 @@ public final class BottomSheetView: UIView {
     }
 
     private var isDismissable: Bool {
-        return dismissalDelegate?.bottomSheetViewCanDismiss(self) ?? false
+        return dismissalDelegate?.bottomSheetViewCanDismissWithGesture(self) ?? false
     }
 
     private lazy var handleView: UIView = {

--- a/Sources/BottomSheetView.swift
+++ b/Sources/BottomSheetView.swift
@@ -26,7 +26,7 @@ extension Array where Element == CGFloat {
 
 // MARK: - Delegate
 
-public protocol BottomSheetViewDelegate: AnyObject {
+public protocol BottomSheetViewActionDelegate: AnyObject {
     func bottomSheetViewDidTapDimView(_ view: BottomSheetView)
     func bottomSheetViewDidReachDismissArea(_ view: BottomSheetView, with velocity: CGPoint)
 }
@@ -55,7 +55,7 @@ public final class BottomSheetView: UIView {
         }
     }
 
-    public weak var delegate: BottomSheetViewDelegate?
+    public weak var actionDelegate: BottomSheetViewActionDelegate?
     public weak var animationDelegate: BottomSheetViewAnimationDelegate?
     public private(set) var contentHeights: [CGFloat]
 
@@ -343,11 +343,19 @@ public final class BottomSheetView: UIView {
                 for: location
             )
 
-            if translationTarget.isDismissible {
-                delegate?.bottomSheetViewDidReachDismissArea(self, with: velocity)
-            } else {
+            func animateToTranslationTarget() {
                 animate(to: translationTarget.targetOffset, with: velocity)
                 createTranslationTargets()
+            }
+
+            // if it's the bottom limit target
+            if translationTarget.isDismissible {
+                if !isDismissable {
+                    animateToTranslationTarget()
+                }
+                actionDelegate?.bottomSheetViewDidReachDismissArea(self, with: velocity)
+            } else {
+                animateToTranslationTarget()
             }
 
         default:
@@ -358,7 +366,7 @@ public final class BottomSheetView: UIView {
     // MARK: - UITapGestureRecognizer
 
     @objc private func handleTap(tapGesture: UITapGestureRecognizer) {
-        delegate?.bottomSheetViewDidTapDimView(self)
+        actionDelegate?.bottomSheetViewDidTapDimView(self)
     }
 
     // MARK: - Offset calculation

--- a/Sources/BottomSheetView.swift
+++ b/Sources/BottomSheetView.swift
@@ -68,10 +68,6 @@ public final class BottomSheetView: UIView {
         set { dimView.isHidden = newValue }
     }
 
-    // MARK: - Internal properties
-
-    
-
     // MARK: - Private properties
 
     private let useSafeAreaInsets: Bool

--- a/Sources/TranslationTarget.swift
+++ b/Sources/TranslationTarget.swift
@@ -11,9 +11,8 @@ protocol TranslationTarget {
     /// An offset which a BottomSheetView can transition to
     var targetOffset: CGFloat { get }
 
-    /// Flag specifying whether a BottomSheetView should be dismissed.
-    /// This should only be used when presented by a presentation controller
-    var isDismissible: Bool { get }
+    /// Flag specifying whether it is a bottom limit target.
+    var isBottomTarget: Bool { get }
 
     /// BottomSheetView will find the model which contains the current translation offset
     /// and transition to its target offset when its gesture ends.
@@ -56,7 +55,7 @@ enum TranslationBehavior {
 struct RangeTarget: TranslationTarget {
     let targetOffset: CGFloat
     let range: Range<CGFloat>
-    let isDismissible: Bool
+    let isBottomTarget: Bool
 
     func contains(offset: CGFloat) -> Bool {
         range.contains(offset)
@@ -87,7 +86,7 @@ struct LimitTarget: TranslationTarget {
     let targetOffset: CGFloat
     let bound: CGFloat
     let behavior: TranslationBehavior
-    let isDismissible: Bool
+    let isBottomTarget: Bool
     let compare: (CGFloat, CGFloat) -> Bool
 
     func contains(offset: CGFloat) -> Bool {

--- a/Tests/BottomSheetCalculatorTests.swift
+++ b/Tests/BottomSheetCalculatorTests.swift
@@ -27,11 +27,11 @@ final class BottomSheetCalculatorTests: XCTestCase {
     }
 
     func testLayoutWithEmptyOffsets() {
-        XCTAssertTrue(BottomSheetCalculator.createTranslationTargets(for: [], at: 0, in: superview, isDismissible: false).isEmpty)
+        XCTAssertTrue(BottomSheetCalculator.createTranslationTargets(for: [], at: 0, in: superview, targetMaxHeight: false).isEmpty)
     }
 
     func testLayoutModelsWithSingleOffset() {
-        let models = BottomSheetCalculator.createTranslationTargets(for: [500], at: 0, in: superview, isDismissible: false)
+        let models = BottomSheetCalculator.createTranslationTargets(for: [500], at: 0, in: superview, targetMaxHeight: false)
 
         XCTAssertEqual(models.count, 3)
         XCTAssertTrue(models[0] is LimitTarget)
@@ -40,7 +40,7 @@ final class BottomSheetCalculatorTests: XCTestCase {
     }
 
     func testLayoutModelsWithMultipleOffsets() {
-        let models = BottomSheetCalculator.createTranslationTargets(for: [700, 300, 100], at: 0, in: superview, isDismissible: false)
+        let models = BottomSheetCalculator.createTranslationTargets(for: [700, 300, 100], at: 0, in: superview, targetMaxHeight: false)
 
         XCTAssertEqual(models.count, 5)
         XCTAssertTrue(models.first is LimitTarget)
@@ -48,7 +48,7 @@ final class BottomSheetCalculatorTests: XCTestCase {
     }
 
     func testLayoutModelsWhenContainingOffset() {
-        let models = BottomSheetCalculator.createTranslationTargets(for: [700, 300, 100], at: 0, in: superview, isDismissible: false)
+        let models = BottomSheetCalculator.createTranslationTargets(for: [700, 300, 100], at: 0, in: superview, targetMaxHeight: false)
 
         XCTAssertTrue(models[0].contains(offset: 800))
         XCTAssertTrue(models[1].contains(offset: 690))
@@ -59,7 +59,7 @@ final class BottomSheetCalculatorTests: XCTestCase {
     }
 
     func testLayoutModelsWhenNotContainingOffset() {
-        let models = BottomSheetCalculator.createTranslationTargets(for: [700, 300, 100], at: 0, in: superview, isDismissible: false)
+        let models = BottomSheetCalculator.createTranslationTargets(for: [700, 300, 100], at: 0, in: superview, targetMaxHeight: false)
         XCTAssertFalse(models[0].contains(offset: 600))
         XCTAssertFalse(models[1].contains(offset: 300))
         XCTAssertFalse(models[2].contains(offset: 100))
@@ -68,7 +68,7 @@ final class BottomSheetCalculatorTests: XCTestCase {
     }
 
     func testLayoutThresholds() {
-        let models = BottomSheetCalculator.createTranslationTargets(for: [700, 600, 400], at: 1, in: superview, isDismissible: false)
+        let models = BottomSheetCalculator.createTranslationTargets(for: [700, 600, 400], at: 1, in: superview, targetMaxHeight: false)
 
         guard let firstModel = models[1] as? RangeTarget else {
             return

--- a/Tests/BottomSheetModelTests.swift
+++ b/Tests/BottomSheetModelTests.swift
@@ -11,7 +11,7 @@ final class BottomSheetModelTests: XCTestCase {
         let rangeModel = RangeTarget(
             targetOffset: 500,
             range: 300 ..< 600,
-            isDismissible: false
+            isBottomTarget: false
         )
 
         XCTAssertFalse(rangeModel.contains(offset: 200))
@@ -27,7 +27,7 @@ final class BottomSheetModelTests: XCTestCase {
             targetOffset: targetOffset,
             bound: targetOffset,
             behavior: .stop,
-            isDismissible: false,
+            isBottomTarget: false,
             compare: <
         )
 
@@ -44,7 +44,7 @@ final class BottomSheetModelTests: XCTestCase {
             targetOffset: bound,
             bound: bound,
             behavior: .rubberBand(radius: radius),
-            isDismissible: false,
+            isBottomTarget: false,
             compare: <
         )
 
@@ -64,7 +64,7 @@ final class BottomSheetModelTests: XCTestCase {
             targetOffset: targetOffset,
             bound: 700,
             behavior: .linear,
-            isDismissible: false,
+            isBottomTarget: false,
             compare: >=
         )
 


### PR DESCRIPTION
# Why?

In order to support existing bottom sheet functionality we need a way to observe dismissal events and disable dismiss if needed.

# What?

- Set `isDismissable` to always be true for bottom limit target. It allows to check if the 
translation target is within the dismiss area, no matter whether the bottom sheet view can be dismissed with gesture or not

- Rename `BottomSheetViewDelegate` to `BottomSheetViewDismissalDelegate` and add additional `bottomSheetViewCanDismissWithGesture` function to enable/disable dismiss gestures when needed

- Construct `BottomSheetView` and `BottomSheetTransitioningDelegate` with optional dismissal delegate

Now it should be possible to present confirmation dialog to prevent dismissing the bottom sheet by accident. 

# Show me

No UI changes.