### PR TITLE
Override navigation controller init

### DIFF
--- a/Sources/BottomSheetNavigationController.swift
+++ b/Sources/BottomSheetNavigationController.swift
@@ -20,8 +20,12 @@ open class BottomSheetNavigationController: UINavigationController {
         modalPresentationStyle = .custom
     }
 
+    public override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+        super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+    }
+
     public required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        super.init(coder: aDecoder)
     }
 
     // MARK: - View lifecycle

--- a/Sources/BottomSheetView.swift
+++ b/Sources/BottomSheetView.swift
@@ -62,6 +62,7 @@ public final class BottomSheetView: UIView {
     public weak var dismissalDelegate: BottomSheetViewDismissalDelegate?
     public weak var animationDelegate: BottomSheetViewAnimationDelegate?
     public private(set) var contentHeights: [CGFloat]
+    public private(set) var currentTargetOffsetIndex: Int = 0
 
     public var isDimViewHidden: Bool {
         get { dimView.isHidden }
@@ -75,7 +76,6 @@ public final class BottomSheetView: UIView {
     private let handleBackground: HandleBackground
     private var topConstraint: NSLayoutConstraint!
     private var targetOffsets = [CGFloat]()
-    private var currentTargetOffsetIndex: Int = 0
 
     private var initialOffset: CGFloat?
     private var translationTargets = [TranslationTarget]()


### PR DESCRIPTION
# Why?

Apparently we should override `init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?)` when subclassing `UINavigationController`. Otherwise it results in a crash "Fatal error: Use of unimplemented initializer ‘init(nibName:bundle:)’ for class".

# What?

Override `init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?)`

# Show me

No UI changes.