### PR TITLE
Make it possible to stretch content view on resize

### DIFF
--- a/Sources/BottomSheetPresentationController.swift
+++ b/Sources/BottomSheetPresentationController.swift
@@ -45,6 +45,7 @@ final class BottomSheetPresentationController: UIPresentationController {
     private let startTargetIndex: Int
     private let handleBackground: BottomSheetView.HandleBackground
     private let useSafeAreaInsets: Bool
+    private let stretchOnResize: Bool
     private var dismissVelocity: CGPoint = .zero
     private var bottomSheetView: BottomSheetView?
     private var dismissAction: BottomSheetView.DismissAction?
@@ -62,7 +63,8 @@ final class BottomSheetPresentationController: UIPresentationController {
         presentationDelegate: BottomSheetPresentationControllerDelegate?,
         animationDelegate: BottomSheetViewAnimationDelegate?,
         handleBackground: BottomSheetView.HandleBackground,
-        useSafeAreaInsets: Bool
+        useSafeAreaInsets: Bool,
+        stretchOnResize: Bool
     ) {
         self.contentHeights = contentHeights
         self.startTargetIndex = startTargetIndex
@@ -70,6 +72,7 @@ final class BottomSheetPresentationController: UIPresentationController {
         self.presentationDelegate = presentationDelegate
         self.animationDelegate = animationDelegate
         self.useSafeAreaInsets = useSafeAreaInsets
+        self.stretchOnResize = stretchOnResize
         super.init(presentedViewController: presentedViewController, presenting: presenting)
     }
 
@@ -146,6 +149,7 @@ final class BottomSheetPresentationController: UIPresentationController {
             contentHeights: contentHeights,
             handleBackground: handleBackground,
             useSafeAreaInsets: useSafeAreaInsets,
+            stretchOnResize: stretchOnResize,
             dismissalDelegate: self,
             animationDelegate: animationDelegate
         )

--- a/Sources/BottomSheetTransitioningDelegate.swift
+++ b/Sources/BottomSheetTransitioningDelegate.swift
@@ -9,6 +9,7 @@ public final class BottomSheetTransitioningDelegate: NSObject {
     private let startTargetIndex: Int
     private let handleBackground: BottomSheetView.HandleBackground
     private let useSafeAreaInsets: Bool
+    private let stretchOnResize: Bool
     private var weakPresentationController: WeakRef<BottomSheetPresentationController>?
     private weak var presentationDelegate: BottomSheetPresentationControllerDelegate?
     private weak var animationDelegate: BottomSheetViewAnimationDelegate?
@@ -25,7 +26,8 @@ public final class BottomSheetTransitioningDelegate: NSObject {
         handleBackground: BottomSheetView.HandleBackground = .color(.clear),
         presentationDelegate: BottomSheetPresentationControllerDelegate? = nil,
         animationDelegate: BottomSheetViewAnimationDelegate? = nil,
-        useSafeAreaInsets: Bool = false
+        useSafeAreaInsets: Bool = false,
+        stretchOnResize: Bool = false
     ) {
         self.contentHeights = contentHeights
         self.startTargetIndex = startTargetIndex
@@ -33,6 +35,7 @@ public final class BottomSheetTransitioningDelegate: NSObject {
         self.presentationDelegate = presentationDelegate
         self.animationDelegate = animationDelegate
         self.useSafeAreaInsets = useSafeAreaInsets
+        self.stretchOnResize = stretchOnResize
     }
 
     // MARK: - Public
@@ -73,7 +76,8 @@ extension BottomSheetTransitioningDelegate: UIViewControllerTransitioningDelegat
             presentationDelegate: presentationDelegate,
             animationDelegate: animationDelegate,
             handleBackground: handleBackground,
-            useSafeAreaInsets: useSafeAreaInsets
+            useSafeAreaInsets: useSafeAreaInsets,
+            stretchOnResize: stretchOnResize
         )
         self.weakPresentationController = WeakRef(value: presentationController)
         return presentationController

--- a/Sources/BottomSheetView.swift
+++ b/Sources/BottomSheetView.swift
@@ -72,6 +72,7 @@ public final class BottomSheetView: UIView {
     // MARK: - Private properties
 
     private let useSafeAreaInsets: Bool
+    private let stretchOnResize: Bool
     private let contentView: UIView
     private let handleBackground: HandleBackground
     private var topConstraint: NSLayoutConstraint!
@@ -115,6 +116,7 @@ public final class BottomSheetView: UIView {
         contentHeights: [CGFloat],
         handleBackground: HandleBackground = .color(.clear),
         useSafeAreaInsets: Bool = false,
+        stretchOnResize: Bool = false,
         dismissalDelegate: BottomSheetViewDismissalDelegate? = nil,
         animationDelegate: BottomSheetViewAnimationDelegate? = nil
     ) {
@@ -122,6 +124,7 @@ public final class BottomSheetView: UIView {
         self.handleBackground = handleBackground
         self.contentHeights = contentHeights.isEmpty ? [.bottomSheetAutomatic] : contentHeights
         self.useSafeAreaInsets = useSafeAreaInsets
+        self.stretchOnResize = stretchOnResize
         self.dismissalDelegate = dismissalDelegate
         self.animationDelegate = animationDelegate
         super.init(frame: .zero)
@@ -284,7 +287,7 @@ public final class BottomSheetView: UIView {
         handleBackgroundView.translatesAutoresizingMaskIntoConstraints = false
         contentView.translatesAutoresizingMaskIntoConstraints = false
 
-        NSLayoutConstraint.activate([
+        var constraints = [
             handleBackgroundView.topAnchor.constraint(equalTo: topAnchor),
             handleBackgroundView.leadingAnchor.constraint(equalTo: leadingAnchor),
             handleBackgroundView.trailingAnchor.constraint(equalTo: trailingAnchor),
@@ -298,8 +301,15 @@ public final class BottomSheetView: UIView {
             contentView.topAnchor.constraint(equalTo: handleView.bottomAnchor, constant: 8),
             contentView.leadingAnchor.constraint(equalTo: leadingAnchor),
             contentView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            contentView.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor, constant: -bottomInset)
-        ])
+        ]
+
+        if stretchOnResize {
+            constraints.append(contentView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -bottomInset))
+        } else {
+            constraints.append(contentView.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor, constant: -bottomInset))
+        }
+
+        NSLayoutConstraint.activate(constraints)
     }
 
     // MARK: - Animations


### PR DESCRIPTION
# Why?

It should be possible to configure the bottom sheet to stretch the content view when target height changes. This will be useful, e.g. for view controllers with table views.

# What?

- Add `stretchOnResize` configuration parameter to `BottomSheetView` and `BottomSheetTransitioningDlegate`
- Constrain content view to the bottom of the bottom sheet view when `stretchOnResize` is set to true

# Show me

| `stretchOnResize = false` | `stretchOnResize = true` |
| --- | --- |
| ![false](https://user-images.githubusercontent.com/10529867/72348048-c8a0b580-36d9-11ea-8a07-2687bce40a95.gif) | ![true](https://user-images.githubusercontent.com/10529867/72348065-d22a1d80-36d9-11ea-9ce4-10b9032292a0.gif) |