### PR TITLE
Draggable height as configuration option

### DIFF
--- a/Sources/BottomSheetNavigationController.swift
+++ b/Sources/BottomSheetNavigationController.swift
@@ -10,11 +10,20 @@ open class BottomSheetNavigationController: UINavigationController {
 
     // MARK: - Init
 
-    public init(rootViewController: UIViewController, useSafeAreaInsets: Bool = false) {
+    public init(
+        rootViewController: UIViewController,
+        handleBackground: BottomSheetView.HandleBackground = .color(.clear),
+        draggableHeight: CGFloat? = nil,
+        useSafeAreaInsets: Bool = false,
+        stretchOnResize: Bool = false
+    ) {
         super.init(rootViewController: rootViewController)
         bottomSheetTransitioningDelegate = BottomSheetTransitioningDelegate(
             contentHeights: [systemLayoutSizeFittingHeight(for: rootViewController)],
-            useSafeAreaInsets: useSafeAreaInsets
+            handleBackground: handleBackground,
+            draggableHeight: draggableHeight,
+            useSafeAreaInsets: useSafeAreaInsets,
+            stretchOnResize: stretchOnResize
         )
         transitioningDelegate = bottomSheetTransitioningDelegate
         modalPresentationStyle = .custom

--- a/Sources/BottomSheetPresentationController.swift
+++ b/Sources/BottomSheetPresentationController.swift
@@ -45,6 +45,7 @@ final class BottomSheetPresentationController: UIPresentationController {
     private let startTargetIndex: Int
     private let handleBackground: BottomSheetView.HandleBackground
     private let useSafeAreaInsets: Bool
+    private let draggableHeight: CGFloat?
     private let stretchOnResize: Bool
     private var dismissVelocity: CGPoint = .zero
     private var bottomSheetView: BottomSheetView?
@@ -63,12 +64,14 @@ final class BottomSheetPresentationController: UIPresentationController {
         presentationDelegate: BottomSheetPresentationControllerDelegate?,
         animationDelegate: BottomSheetViewAnimationDelegate?,
         handleBackground: BottomSheetView.HandleBackground,
+        draggableHeight: CGFloat?,
         useSafeAreaInsets: Bool,
         stretchOnResize: Bool
     ) {
         self.contentHeights = contentHeights
         self.startTargetIndex = startTargetIndex
         self.handleBackground = handleBackground
+        self.draggableHeight = draggableHeight
         self.presentationDelegate = presentationDelegate
         self.animationDelegate = animationDelegate
         self.useSafeAreaInsets = useSafeAreaInsets
@@ -148,6 +151,7 @@ final class BottomSheetPresentationController: UIPresentationController {
             contentView: presentedView,
             contentHeights: contentHeights,
             handleBackground: handleBackground,
+            draggableHeight: draggableHeight,
             useSafeAreaInsets: useSafeAreaInsets,
             stretchOnResize: stretchOnResize,
             dismissalDelegate: self,

--- a/Sources/BottomSheetTransitioningDelegate.swift
+++ b/Sources/BottomSheetTransitioningDelegate.swift
@@ -8,6 +8,7 @@ public final class BottomSheetTransitioningDelegate: NSObject {
     public private(set) var contentHeights: [CGFloat]
     private let startTargetIndex: Int
     private let handleBackground: BottomSheetView.HandleBackground
+    private let draggableHeight: CGFloat?
     private let useSafeAreaInsets: Bool
     private let stretchOnResize: Bool
     private var weakPresentationController: WeakRef<BottomSheetPresentationController>?
@@ -24,6 +25,7 @@ public final class BottomSheetTransitioningDelegate: NSObject {
         contentHeights: [CGFloat],
         startTargetIndex: Int = 0,
         handleBackground: BottomSheetView.HandleBackground = .color(.clear),
+        draggableHeight: CGFloat? = nil,
         presentationDelegate: BottomSheetPresentationControllerDelegate? = nil,
         animationDelegate: BottomSheetViewAnimationDelegate? = nil,
         useSafeAreaInsets: Bool = false,
@@ -32,6 +34,7 @@ public final class BottomSheetTransitioningDelegate: NSObject {
         self.contentHeights = contentHeights
         self.startTargetIndex = startTargetIndex
         self.handleBackground = handleBackground
+        self.draggableHeight = draggableHeight
         self.presentationDelegate = presentationDelegate
         self.animationDelegate = animationDelegate
         self.useSafeAreaInsets = useSafeAreaInsets
@@ -76,6 +79,7 @@ extension BottomSheetTransitioningDelegate: UIViewControllerTransitioningDelegat
             presentationDelegate: presentationDelegate,
             animationDelegate: animationDelegate,
             handleBackground: handleBackground,
+            draggableHeight: draggableHeight,
             useSafeAreaInsets: useSafeAreaInsets,
             stretchOnResize: stretchOnResize
         )

--- a/Sources/BottomSheetView.swift
+++ b/Sources/BottomSheetView.swift
@@ -435,8 +435,9 @@ private class PanGestureRecognizer: UIPanGestureRecognizer {
             return super.touchesBegan(touches, with: event)
         }
 
+        let height = CGFloat.handleHeight + draggableHeight
         let touchPoint = firstTouch.location(in: view)
-        let draggableRect = CGRect(x: 0, y: 0, width: view.frame.width, height: draggableHeight)
+        let draggableRect = CGRect(x: 0, y: 0, width: view.frame.width, height: height)
 
         if draggableRect.contains(touchPoint) {
             super.touchesBegan(touches, with: event)


### PR DESCRIPTION
# Why?

To make our migration from the old bottom sheet as smooth as possible we need to make draggable height configurable in our public API.

# What?

- Add `draggableHeight` as configuration to the bottom sheet view and transitioning delegate
- Add missing configuration to `BottomSheetNavigationController`

# Show me

![drag](https://user-images.githubusercontent.com/10529867/72361104-36a4a700-36f1-11ea-87c5-2a09936f674f.gif)