### PR TITLE
Fix: Crash on present/dismiss of bottomSheetView

### DIFF
--- a/Sources/BottomSheetPresentationController.swift
+++ b/Sources/BottomSheetPresentationController.swift
@@ -184,12 +184,18 @@ extension BottomSheetPresentationController: UIViewControllerAnimatedTransitioni
 
         switch transitionState {
         case .presenting:
+            guard bottomSheetView?.superview == nil else {
+                return
+            }
             bottomSheetView?.present(
                 in: transitionContext.containerView,
                 targetIndex: startTargetIndex,
                 completion: completion
             )
         case .dismissing:
+            guard bottomSheetView?.superview != nil else {
+                return
+            }
             bottomSheetView?.dismiss(
                 velocity: dismissVelocity,
                 completion: completion


### PR DESCRIPTION
# Why?
Ref. these two crashes:
- https://console.firebase.google.com/u/0/project/fir-ios-finn/crashlytics/app/ios:no.finn.ipad.rubrikk/issues/800c8dff9b320ff725300095d6fc2fbe
- https://console.firebase.google.com/u/0/project/fir-ios-finn/crashlytics/app/ios:no.finn.ipad.rubrikk/issues/be9338d38c7d3319e8a6807d58286081

It seems the bottomsheet is sometimes trying to present/dismiss twice, potentially in rapid succession. I haven't been able to reproduce this, and I'm not sure if this is the right solution, but I guess it's worth to try. There has been a lot of crashes for this across multiple versions in the last weeks/months.

# What?
- Make sure the presented view's superview is `nil` before presenting it, and not `nil` before dismissal.