### PR TITLE
The CADisplayLink should be invalidated after use

### DIFF
--- a/Sources/BottomSheetView.swift
+++ b/Sources/BottomSheetView.swift
@@ -222,6 +222,7 @@ public final class BottomSheetView: UIView {
                 self?.contentView.removeFromSuperview()
                 self?.dimView.removeFromSuperview()
                 self?.removeFromSuperview()
+                self?.springAnimator.invalidate()
             }
 
             completion?(didComplete)

--- a/Sources/SpringAnimator.swift
+++ b/Sources/SpringAnimator.swift
@@ -104,6 +104,10 @@ class SpringAnimator: NSObject {
         state = .stopped
         completion?(!withoutFinishing)
     }
+
+    func invalidate() {
+        displayLink.invalidate()
+    }
 }
 
 private extension SpringAnimator {


### PR DESCRIPTION
# Why?

Because not calling `invalidate()` will cause the CADisplayLink to leak. Because of a strong ref to the target.

[func invalidate()](https://developer.apple.com/documentation/quartzcore/cadisplaylink/1621293-invalidate):
```
Removing the display link from all run loop modes causes it to be released by the run loop. 
The display link also releases the target.
```

# What?

Added a `invalidate()` function to the SpringAnimator to invalidate the CADisplayLink after completed dismiss.

# Show me

<img width="271" alt="Screenshot 2020-09-14 at 12 25 16" src="https://user-images.githubusercontent.com/1153104/93076163-36e1b180-f687-11ea-8e85-c7cf6f9143ab.png">
