### PR TITLE
Add public methods to copy/hide background overlay

### DIFF
--- a/Sources/BottomSheetPresentationController.swift
+++ b/Sources/BottomSheetPresentationController.swift
@@ -39,6 +39,10 @@ final class BottomSheetPresentationController: UIPresentationController {
 
     var transitionState: TransitionState?
 
+    var dimViewBackgroundColor: UIColor? {
+        bottomSheetView?.dimViewBackgroundColor
+    }
+
     // MARK: - Private properties
 
     private var contentHeights: [CGFloat]
@@ -80,6 +84,10 @@ final class BottomSheetPresentationController: UIPresentationController {
     }
 
     // MARK: - Internal
+
+    func hideDimView() {
+        bottomSheetView?.hideDimView()
+    }
 
     func transition(to index: Int) {
         bottomSheetView?.transition(to: index)

--- a/Sources/BottomSheetPresentationController.swift
+++ b/Sources/BottomSheetPresentationController.swift
@@ -85,10 +85,6 @@ final class BottomSheetPresentationController: UIPresentationController {
 
     // MARK: - Internal
 
-    func hideDimView() {
-        bottomSheetView?.hideDimView()
-    }
-
     func transition(to index: Int) {
         bottomSheetView?.transition(to: index)
     }
@@ -100,6 +96,10 @@ final class BottomSheetPresentationController: UIPresentationController {
     func reload(with contentHeights: [CGFloat]) {
         self.contentHeights = contentHeights
         bottomSheetView?.reload(with: contentHeights)
+    }
+
+    func hideDimView() {
+        bottomSheetView?.hideDimView()
     }
 
     // MARK: - Transition life cycle

--- a/Sources/BottomSheetTransitioningDelegate.swift
+++ b/Sources/BottomSheetTransitioningDelegate.swift
@@ -19,6 +19,10 @@ public final class BottomSheetTransitioningDelegate: NSObject {
         return weakPresentationController?.value
     }
 
+    public var backgroundOverlayColor: UIColor? {
+        presentationController?.dimViewBackgroundColor
+    }
+
     // MARK: - Init
 
     public init(
@@ -60,6 +64,10 @@ public final class BottomSheetTransitioningDelegate: NSObject {
     public func reload(with contentHeights: [CGFloat]) {
         self.contentHeights = contentHeights
         presentationController?.reload(with: contentHeights)
+    }
+
+    public func hideBackgroundOverlay() {
+        presentationController?.hideDimView()
     }
 }
 

--- a/Sources/BottomSheetView.swift
+++ b/Sources/BottomSheetView.swift
@@ -71,6 +71,10 @@ public final class BottomSheetView: UIView {
 
     public let draggableHeight: CGFloat?
 
+    var dimViewBackgroundColor: UIColor? {
+        dimView.backgroundColor
+    }
+
     // MARK: - Private properties
 
     private let useSafeAreaInsets: Bool
@@ -113,10 +117,6 @@ public final class BottomSheetView: UIView {
     }()
 
     private lazy var contentViewHeightConstraint = contentView.heightAnchor.constraint(greaterThanOrEqualToConstant: 0)
-
-    var dimViewBackgroundColor: UIColor? {
-        dimView.backgroundColor
-    }
 
     // MARK: - Init
 

--- a/Sources/BottomSheetView.swift
+++ b/Sources/BottomSheetView.swift
@@ -114,6 +114,10 @@ public final class BottomSheetView: UIView {
 
     private lazy var contentViewHeightConstraint = contentView.heightAnchor.constraint(greaterThanOrEqualToConstant: 0)
 
+    var dimViewBackgroundColor: UIColor? {
+        dimView.backgroundColor
+    }
+
     // MARK: - Init
 
     public init(
@@ -317,6 +321,12 @@ public final class BottomSheetView: UIView {
         }
 
         NSLayoutConstraint.activate(constraints)
+    }
+
+    // MARK: - Internal methods
+
+    func hideDimView() {
+        dimView.removeFromSuperview()
     }
 
     // MARK: - Animations


### PR DESCRIPTION
# Why?

We have a very special use case in the app, where we would like to keep the background overlay behind the bottom sheet when it dismisses. Instead of letting the background get lighter as the bottom sheet dismisses, as it is implemented here.

# What?

- Add public var to get the current color of background view
- Add public method to hide the background view from here

In this way, I am allowed to make a copy of the background view in another view controller, and take over the animation from there. I know this is very edge-casey 😅 

# Show me
Here you can see the background view is not removed until _after_ the map search is closed. We did this, to give the user a better feeling of the map opening _on top_ of the search results list in full screen view. 

![dimview](https://user-images.githubusercontent.com/17450858/95327024-c0119000-08a3-11eb-9012-9fbe2e835121.gif)
