### PR TITLE
Reset contentViewHeightConstraint

### DIFF
--- a/Sources/BottomSheetView.swift
+++ b/Sources/BottomSheetView.swift
@@ -410,6 +410,8 @@ public final class BottomSheetView: UIView {
 
     private func updateTargetOffsets() {
         guard let superview = superview else { return }
+        
+        contentViewHeightConstraint.constant = 0
 
         targetOffsets = contentHeights.map {
             BottomSheetCalculator.offset(for: contentView, in: superview, height: $0, useSafeAreaInsets: useSafeAreaInsets)


### PR DESCRIPTION
# Why?

`contentViewHeightConstraint.constant` is not reset, hence the height calculation won't return the correct height for the `contentView` if its shrunk. This is because it will return the previous height if the view.

# What?

Set `contentViewHeightConstraint.constant = 0` on `reset()`

# Show me

| Before | After |
| --- | --- |
| ![Kapture 2020-11-11 at 12 40 27](https://user-images.githubusercontent.com/3852639/98807874-96f09c00-241b-11eb-8ba4-e2efe05a06f4.gif) | ![Kapture 2020-11-11 at 12 40 57](https://user-images.githubusercontent.com/3852639/98807882-9a842300-241b-11eb-8ffa-261ae9e2664a.gif) |


