### PR TITLE
Accessibility improvement

### DIFF
--- a/BottomSheet.xcodeproj/project.pbxproj
+++ b/BottomSheet.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5D5A7BF1256BA2A900FD1820 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5D5A7BEF256BA2A900FD1820 /* Localizable.strings */; };
 		5DAC3BF4256964C60052400F /* HandleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DAC3BF3256964C60052400F /* HandleView.swift */; };
 		5DAC3BFB256966C50052400F /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5DAC3BF9256966C50052400F /* Localizable.strings */; };
 		5DAC3C02256967B10052400F /* String+Localized.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DAC3C01256967B10052400F /* String+Localized.swift */; };
@@ -61,6 +62,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		5D5A7BF0256BA2A900FD1820 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = Localizable.strings; sourceTree = "<group>"; };
 		5DAC3BF3256964C60052400F /* HandleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HandleView.swift; sourceTree = "<group>"; };
 		5DAC3BFA256966C50052400F /* nb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nb; path = Localizable.strings; sourceTree = "<group>"; };
 		5DAC3C01256967B10052400F /* String+Localized.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Localized.swift"; sourceTree = "<group>"; };
@@ -113,9 +115,18 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		5D5A7BEC256BA27300FD1820 /* en.lproj */ = {
+			isa = PBXGroup;
+			children = (
+				5D5A7BEF256BA2A900FD1820 /* Localizable.strings */,
+			);
+			path = en.lproj;
+			sourceTree = "<group>";
+		};
 		5DAC3BF7256966800052400F /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				5D5A7BEC256BA27300FD1820 /* en.lproj */,
 				5DAC3BF8256966870052400F /* nb.lproj */,
 			);
 			path = Resources;
@@ -324,6 +335,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5DAC3BFB256966C50052400F /* Localizable.strings in Resources */,
+				5D5A7BF1256BA2A900FD1820 /* Localizable.strings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -417,6 +429,14 @@
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
+		5D5A7BEF256BA2A900FD1820 /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				5D5A7BF0256BA2A900FD1820 /* en */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
 		5DAC3BF9256966C50052400F /* Localizable.strings */ = {
 			isa = PBXVariantGroup;
 			children = (

--- a/BottomSheet.xcodeproj/project.pbxproj
+++ b/BottomSheet.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		5DAC3BF4256964C60052400F /* HandleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DAC3BF3256964C60052400F /* HandleView.swift */; };
+		5DAC3BFB256966C50052400F /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5DAC3BF9256966C50052400F /* Localizable.strings */; };
+		5DAC3C02256967B10052400F /* String+Localized.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DAC3C01256967B10052400F /* String+Localized.swift */; };
 		CF1539C72382F20E001687C1 /* BottomSheet.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CF1539BD2382F20E001687C1 /* BottomSheet.framework */; };
 		CF1539CC2382F20E001687C1 /* BottomSheetCalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF1539CB2382F20E001687C1 /* BottomSheetCalculatorTests.swift */; };
 		CF1539CE2382F20E001687C1 /* BottomSheet.h in Headers */ = {isa = PBXBuildFile; fileRef = CF1539C02382F20E001687C1 /* BottomSheet.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -60,6 +62,8 @@
 
 /* Begin PBXFileReference section */
 		5DAC3BF3256964C60052400F /* HandleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HandleView.swift; sourceTree = "<group>"; };
+		5DAC3BFA256966C50052400F /* nb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nb; path = Localizable.strings; sourceTree = "<group>"; };
+		5DAC3C01256967B10052400F /* String+Localized.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Localized.swift"; sourceTree = "<group>"; };
 		CF1539BD2382F20E001687C1 /* BottomSheet.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BottomSheet.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CF1539C02382F20E001687C1 /* BottomSheet.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BottomSheet.h; sourceTree = "<group>"; };
 		CF1539C12382F20E001687C1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -109,6 +113,30 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		5DAC3BF7256966800052400F /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				5DAC3BF8256966870052400F /* nb.lproj */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
+		5DAC3BF8256966870052400F /* nb.lproj */ = {
+			isa = PBXGroup;
+			children = (
+				5DAC3BF9256966C50052400F /* Localizable.strings */,
+			);
+			path = nb.lproj;
+			sourceTree = "<group>";
+		};
+		5DAC3C002569679E0052400F /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				5DAC3C01256967B10052400F /* String+Localized.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 		CF1539B32382F20E001687C1 = {
 			isa = PBXGroup;
 			children = (
@@ -133,6 +161,8 @@
 		CF1539BF2382F20E001687C1 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				5DAC3C002569679E0052400F /* Extensions */,
+				5DAC3BF7256966800052400F /* Resources */,
 				CF1539C02382F20E001687C1 /* BottomSheet.h */,
 				CF1539C12382F20E001687C1 /* Info.plist */,
 				CF46A3812385902100FFCB9F /* BottomSheetCalculator.swift */,
@@ -274,6 +304,7 @@
 			knownRegions = (
 				en,
 				Base,
+				nb,
 			);
 			mainGroup = CF1539B32382F20E001687C1;
 			productRefGroup = CF1539BE2382F20E001687C1 /* Products */;
@@ -292,6 +323,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5DAC3BFB256966C50052400F /* Localizable.strings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -339,6 +371,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5DAC3C02256967B10052400F /* String+Localized.swift in Sources */,
 				CF1539FB2382F62A001687C1 /* BottomSheetPresentationController.swift in Sources */,
 				CF46A383238593AD00FFCB9F /* BottomSheetCalculator.swift in Sources */,
 				5DAC3BF4256964C60052400F /* HandleView.swift in Sources */,
@@ -382,6 +415,17 @@
 			targetProxy = CF153A032382F88E001687C1 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		5DAC3BF9256966C50052400F /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				5DAC3BFA256966C50052400F /* nb */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
 		CF1539CF2382F20E001687C1 /* Debug */ = {

--- a/BottomSheet.xcodeproj/project.pbxproj
+++ b/BottomSheet.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5DAC3BF4256964C60052400F /* HandleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DAC3BF3256964C60052400F /* HandleView.swift */; };
 		CF1539C72382F20E001687C1 /* BottomSheet.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CF1539BD2382F20E001687C1 /* BottomSheet.framework */; };
 		CF1539CC2382F20E001687C1 /* BottomSheetCalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF1539CB2382F20E001687C1 /* BottomSheetCalculatorTests.swift */; };
 		CF1539CE2382F20E001687C1 /* BottomSheet.h in Headers */ = {isa = PBXBuildFile; fileRef = CF1539C02382F20E001687C1 /* BottomSheet.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -58,6 +59,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		5DAC3BF3256964C60052400F /* HandleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HandleView.swift; sourceTree = "<group>"; };
 		CF1539BD2382F20E001687C1 /* BottomSheet.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BottomSheet.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CF1539C02382F20E001687C1 /* BottomSheet.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BottomSheet.h; sourceTree = "<group>"; };
 		CF1539C12382F20E001687C1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -140,6 +142,7 @@
 				CF1539F52382F621001687C1 /* BottomSheetView.swift */,
 				CF1539F42382F621001687C1 /* SpringAnimator.swift */,
 				DA0F4AFE238BDB7C002DE188 /* TranslationTarget.swift */,
+				5DAC3BF3256964C60052400F /* HandleView.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -338,6 +341,7 @@
 			files = (
 				CF1539FB2382F62A001687C1 /* BottomSheetPresentationController.swift in Sources */,
 				CF46A383238593AD00FFCB9F /* BottomSheetCalculator.swift in Sources */,
+				5DAC3BF4256964C60052400F /* HandleView.swift in Sources */,
 				CF1539FC2382F62A001687C1 /* BottomSheetTransitioningDelegate.swift in Sources */,
 				DA0F4B00238BDB85002DE188 /* TranslationTarget.swift in Sources */,
 				CF1539FF2382F62A001687C1 /* SpringAnimator.swift in Sources */,

--- a/Demo/Info.plist
+++ b/Demo/Info.plist
@@ -10,6 +10,11 @@
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
+	<key>CFBundleLocalizations</key>
+	<array>
+		<string>en</string>
+		<string>nb</string>
+	</array>
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>

--- a/FINNBottomSheet.podspec
+++ b/FINNBottomSheet.podspec
@@ -12,6 +12,7 @@ Pod::Spec.new do |s|
     s.swift_version    = '5.0'
     s.source           = { :git => 'https://github.com/finn-no/bottom-sheet-ios.git', :tag => s.version }
     s.cocoapods_version = '>= 1.4.0'
-    s.source_files = 'Sources/**/*.{h,m,swift,strings}'
+    s.source_files = 'Sources/**/*.{h,m,swift}'
+    s.resource_bundle = { 'FINNBottomSheet' => ['Sources/**/*.lproj'] }
     s.frameworks = 'Foundation', 'UIKit'
   end

--- a/FINNBottomSheet.podspec
+++ b/FINNBottomSheet.podspec
@@ -12,6 +12,6 @@ Pod::Spec.new do |s|
     s.swift_version    = '5.0'
     s.source           = { :git => 'https://github.com/finn-no/bottom-sheet-ios.git', :tag => s.version }
     s.cocoapods_version = '>= 1.4.0'
-    s.source_files = 'Sources/*.{h,m,swift}'
+    s.source_files = 'Sources/**/*.{h,m,swift,strings}'
     s.frameworks = 'Foundation', 'UIKit'
   end

--- a/FINNBottomSheet.podspec
+++ b/FINNBottomSheet.podspec
@@ -13,6 +13,7 @@ Pod::Spec.new do |s|
     s.source           = { :git => 'https://github.com/finn-no/bottom-sheet-ios.git', :tag => s.version }
     s.cocoapods_version = '>= 1.4.0'
     s.source_files = 'Sources/**/*.{h,m,swift}'
+    s.resources = ['Sources/**/*.lproj']
     s.resource_bundle = { 'FINNBottomSheet' => ['Sources/**/*.lproj'] }
     s.frameworks = 'Foundation', 'UIKit'
   end

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 
 let package = Package(
     name: "FINNBottomSheet",
-    defaultLocalization: "nb",
+    defaultLocalization: "en",
     platforms: [
         .iOS(.v11)
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,7 @@ import PackageDescription
 
 let package = Package(
     name: "FINNBottomSheet",
+    defaultLocalization: "nb",
     platforms: [
         .iOS(.v11)
     ],

--- a/Sources/BottomSheetView.swift
+++ b/Sources/BottomSheetView.swift
@@ -98,11 +98,10 @@ public final class BottomSheetView: UIView {
         return useSafeAreaInsets ? .safeAreaBottomInset : 0
     }
 
-    private lazy var handleView: UIView = {
-        let view = UIView(frame: .zero)
+    private lazy var handleView: HandleView = {
+        let view = HandleView(frame: .zero)
         view.translatesAutoresizingMaskIntoConstraints = false
-        view.backgroundColor = .handle
-        view.layer.cornerRadius = 2
+        view.delegate = self
         return view
     }()
 
@@ -411,7 +410,7 @@ public final class BottomSheetView: UIView {
 
     private func updateTargetOffsets() {
         guard let superview = superview else { return }
-        
+
         contentViewHeightConstraint.constant = 0
 
         targetOffsets = contentHeights.map {
@@ -458,9 +457,18 @@ private class PanGestureRecognizer: UIPanGestureRecognizer {
     }
 }
 
-// MARK: - Private extensions
+// MARK: - HandleViewDelegate
 
-private extension UIColor {
+extension BottomSheetView: HandleViewDelegate {
+    func didPerformAccessibilityActivate(_ view: HandleView) -> Bool {
+        dismissalDelegate?.bottomSheetView(self, willDismissBy: .tap)
+        return true
+    }
+}
+
+// MARK: - Internal extensions
+
+extension UIColor {
     class var handle: UIColor {
         return dynamicColorIfAvailable(
             defaultColor: UIColor(red: 195/255, green: 204/255, blue: 217/255, alpha: 1),

--- a/Sources/BottomSheetView.swift
+++ b/Sources/BottomSheetView.swift
@@ -140,6 +140,7 @@ public final class BottomSheetView: UIView {
         self.animationDelegate = animationDelegate
         super.init(frame: .zero)
         setup()
+        accessibilityViewIsModal = true
     }
 
     public required init?(coder: NSCoder) {

--- a/Sources/Extensions/String+Localized.swift
+++ b/Sources/Extensions/String+Localized.swift
@@ -1,0 +1,17 @@
+//
+//  Copyright © FINN.no. All rights reserved.
+//
+
+import Foundation
+
+#if !SWIFT_PACKAGE
+extension Bundle {
+    static var module: Bundle { Bundle(for: BottomSheetView.self) }
+}
+#endif
+
+extension String {
+    func localized() -> String {
+        NSLocalizedString(self, tableName: nil, bundle: .module, value: "", comment: "")
+    }
+}

--- a/Sources/HandleView.swift
+++ b/Sources/HandleView.swift
@@ -27,7 +27,7 @@ class HandleView: UIView {
 
         isAccessibilityElement = true
         accessibilityTraits = .button
-        accessibilityLabel = "Lukk"
+        accessibilityLabel = "handle_view_accessibility_label".localized()
     }
 
     override func accessibilityActivate() -> Bool {

--- a/Sources/HandleView.swift
+++ b/Sources/HandleView.swift
@@ -1,0 +1,36 @@
+//
+//  Copyright © FINN.no AS. All rights reserved.
+//
+
+import UIKit
+
+protocol HandleViewDelegate: AnyObject {
+    func didPerformAccessibilityActivate(_ view: HandleView) -> Bool
+}
+
+class HandleView: UIView {
+
+    weak var delegate: HandleViewDelegate?
+
+    override init(frame: CGRect) {
+        super.init(frame: .zero)
+        setup()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setup() {
+        backgroundColor = .handle
+        layer.cornerRadius = 2
+
+        isAccessibilityElement = true
+        accessibilityTraits = .button
+        accessibilityLabel = "Lukk"
+    }
+
+    override func accessibilityActivate() -> Bool {
+        delegate?.didPerformAccessibilityActivate(self) ?? false
+    }
+}

--- a/Sources/Resources/en.lproj/Localizable.strings
+++ b/Sources/Resources/en.lproj/Localizable.strings
@@ -1,0 +1,5 @@
+/*
+ Copyright © FINN.no AS. All rights reserved.
+*/
+
+"handle_view_accessibility_label" = "Close";

--- a/Sources/Resources/nb.lproj/Localizable.strings
+++ b/Sources/Resources/nb.lproj/Localizable.strings
@@ -1,0 +1,5 @@
+/*
+ Copyright © FINN.no AS. All rights reserved.
+*/
+
+"handle_view_accessibility_label" = "Lukk";


### PR DESCRIPTION
# Why?

We got a feedback from a user saying that if no button to close the sheet was provided, it's impossible to close when using VoiceOver.

# What?

The main thing here is that the handle is made accessible and will dismiss the sheet if activated. With this PR, the handle will be the first element in the sheet to be read by VoiceOver. 

* Set `accessibilityViewIsModal = true` in `BottomSheetView` to stop VoiceOver from reading content behind the sheet
* Extract `handleView` from `BottomSheetView`, and create `HandleView` to be able to override `accessibilityActivate`
* Make `HandleView` accessible by setting `isAccessibilityElement = true` and `accessibilityTraits = .button`

**Localization**

* Add `Localizable.strings` for both English and Norwegian. I set the default localization of `Package.swift` to `en` as this is an open source project. Any objections? 

# Show me

| Before | After |
| --- | --- |
| ![Kapture 2020-11-23 at 10 27 47](https://user-images.githubusercontent.com/3852639/99946387-925ea880-2d76-11eb-90dc-b879bc3375df.gif) | ![Kapture 2020-11-23 at 10 26 45](https://user-images.githubusercontent.com/3852639/99946413-9a1e4d00-2d76-11eb-8829-7a278e514115.gif) |


