### PR TITLE
Bump swift-tools-version to 5.3

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.3
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
# Why

As #42 states, there is an issue with `Package.swift`. 

# What?

Forgot to bump the `swift-tools-version` to 5.3 when adding resources to the package. 


`swift-tools-version` 5.3 that's bundled with Xcode 12 is needed to include resources, thus `BottomSheet` will require Xcode 12 to be included in a project. 


# Show me

__No UI change__