### PR TITLE
Exclude Info.plist from target in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
         .library(name: "FINNBottomSheet", targets: ["FINNBottomSheet"])
     ],
     targets: [
-        .target(name: "FINNBottomSheet", path: "Sources")
+        .target(name: "FINNBottomSheet", path: "Sources", exclude: ["Info.plist"])
     ],
     swiftLanguageVersions: [.v5]
 )


### PR DESCRIPTION
# Why?

Current Package.swift includes `Info.plist` which leads to a warning in build time. Any non source file should be excluded or marked as resource file in Package.swift.

# What?

This PR adds exclude parameter which contains `Info.plist`