### PR TITLE
Support screens with variable refresh rate

### DIFF
--- a/Sources/SpringAnimator.swift
+++ b/Sources/SpringAnimator.swift
@@ -112,11 +112,8 @@ class SpringAnimator: NSObject {
 
 private extension SpringAnimator {
     @objc func step(displayLink: CADisplayLink) {
+        // Get duration in a way that supports screens with variable refresh rates 
         let duration = displayLink.targetTimestamp - CACurrentMediaTime()
-        let delta = 0.0001
-        if abs(duration - displayLink.duration) >= delta {
-            print("@@ CADisplayLink duration is off, calc: \(duration) vs prop: \(displayLink.duration)")
-        }
         // Calculate new potision
         position += velocity * CGFloat(duration)
         let acceleration = -velocity * damping - position * stiffness


### PR DESCRIPTION
# Why?
The animation seems to lead to freezes on latest iPhone 13 Pro devices.

# What?
Stop using the `duration` property of `CADisplayLink` and use recommended way to calculate duration in an environment where refresh rate can vary.