### PR TITLE
Reset index when reloading with new content heights

### DIFF
--- a/Sources/BottomSheetView.swift
+++ b/Sources/BottomSheetView.swift
@@ -245,6 +245,7 @@ public final class BottomSheetView: UIView {
 
     public func reload(with contentHeights: [CGFloat]) {
         self.contentHeights = contentHeights
+        currentTargetOffsetIndex = 0
         reset()
     }
 


### PR DESCRIPTION
# Why?

The index isn't reset today, so we can get index out of bounds if array count is smaller.

# What?

Reset the index to 0 when configuring with new heights.
What's changed is that the bottom sheet will always animate to height in index 0 (instead of preserving whatever was used last time).