### PR TITLE
Try to keep height of bottomsheet when reloading with new contentHeights

### DIFF
--- a/BottomSheet.xcodeproj/project.pbxproj
+++ b/BottomSheet.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4DB2C6ED27230B6F00C3E559 /* Array+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DB2C6EC27230B6F00C3E559 /* Array+Extensions.swift */; };
 		5D5A7BF1256BA2A900FD1820 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5D5A7BEF256BA2A900FD1820 /* Localizable.strings */; };
 		5DAC3BF4256964C60052400F /* HandleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DAC3BF3256964C60052400F /* HandleView.swift */; };
 		5DAC3BFB256966C50052400F /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5DAC3BF9256966C50052400F /* Localizable.strings */; };
@@ -62,6 +63,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		4DB2C6EC27230B6F00C3E559 /* Array+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Extensions.swift"; sourceTree = "<group>"; };
 		5D5A7BF0256BA2A900FD1820 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = Localizable.strings; sourceTree = "<group>"; };
 		5DAC3BF3256964C60052400F /* HandleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HandleView.swift; sourceTree = "<group>"; };
 		5DAC3BFA256966C50052400F /* nb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nb; path = Localizable.strings; sourceTree = "<group>"; };
@@ -144,6 +146,7 @@
 			isa = PBXGroup;
 			children = (
 				5DAC3C01256967B10052400F /* String+Localized.swift */,
+				4DB2C6EC27230B6F00C3E559 /* Array+Extensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -384,6 +387,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5DAC3C02256967B10052400F /* String+Localized.swift in Sources */,
+				4DB2C6ED27230B6F00C3E559 /* Array+Extensions.swift in Sources */,
 				CF1539FB2382F62A001687C1 /* BottomSheetPresentationController.swift in Sources */,
 				CF46A383238593AD00FFCB9F /* BottomSheetCalculator.swift in Sources */,
 				5DAC3BF4256964C60052400F /* HandleView.swift in Sources */,

--- a/Sources/BottomSheetPresentationController.swift
+++ b/Sources/BottomSheetPresentationController.swift
@@ -133,11 +133,12 @@ final class BottomSheetPresentationController: UIPresentationController {
     override var frameOfPresentedViewInContainerView: CGRect {
         guard let presentedView = presentedView else { return .zero }
         guard let containerView = containerView else { return .zero }
+        guard let height = contentHeights[safe: startTargetIndex] else { return .zero }
 
         let contentHeight = BottomSheetCalculator.contentHeight(
             for: presentedView,
             in: containerView,
-            height: contentHeights[startTargetIndex],
+            height: height,
             useSafeAreaInsets: useSafeAreaInsets
         )
 

--- a/Sources/BottomSheetView.swift
+++ b/Sources/BottomSheetView.swift
@@ -163,7 +163,10 @@ public final class BottomSheetView: UIView {
     ///   - view: the container for the bottom sheet view
     ///   - completion: a closure to be executed when the animation ends
     public func present(in superview: UIView, targetIndex: Int = 0, animated: Bool = true, completion: ((Bool) -> Void)? = nil) {
-        guard self.superview != superview else { return }
+        guard
+            self.superview != superview,
+            let height = contentHeights[safe: targetIndex]
+        else { return }
 
         superview.addSubview(dimView)
         superview.addSubview(self)
@@ -174,7 +177,7 @@ public final class BottomSheetView: UIView {
         let startOffset = BottomSheetCalculator.offset(
             for: contentView,
             in: superview,
-            height: contentHeights[targetIndex],
+            height: height,
             useSafeAreaInsets: useSafeAreaInsets
         )
 
@@ -240,11 +243,14 @@ public final class BottomSheetView: UIView {
     public func reset() {
         updateTargetOffsets()
         createTranslationTargets()
-        animate(to: targetOffsets[currentTargetOffsetIndex])
+
+        if let targetOffset = targetOffsets[safe: currentTargetOffsetIndex] {
+            animate(to: targetOffset)
+        }
     }
 
     public func reload(with contentHeights: [CGFloat]) {
-        let previousHeight = self.contentHeights.count > currentTargetOffsetIndex ? self.contentHeights[currentTargetOffsetIndex] : 0
+        let previousHeight = self.contentHeights[safe: currentTargetOffsetIndex] ?? 0
         let indexOfPreviousHeightInNewHeights = contentHeights.firstIndex(of: previousHeight) ?? 0
         self.contentHeights = contentHeights
         currentTargetOffsetIndex = indexOfPreviousHeightInNewHeights
@@ -256,8 +262,7 @@ public final class BottomSheetView: UIView {
     /// - Parameters:
     ///   - index: the index of the target height
     public func transition(to index: Int) {
-        guard contentHeights.indices.contains(index) else {
-            assertionFailure("Provided index is out of bounds of the array with target heights.")
+        guard let height = contentHeights[safe: index] else {
             return
         }
 
@@ -268,7 +273,7 @@ public final class BottomSheetView: UIView {
         let offset = BottomSheetCalculator.offset(
             for: contentView,
             in: superview,
-            height: contentHeights[index],
+            height: height,
             useSafeAreaInsets: useSafeAreaInsets
         )
 

--- a/Sources/Extensions/Array+Extensions.swift
+++ b/Sources/Extensions/Array+Extensions.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+extension Array {
+    // Returns an Optional that will be nil if index < count
+    subscript(safe index: Int) -> Element? {
+        return indices.contains(index) ? self[index] : .none
+    }
+}


### PR DESCRIPTION
# Why?
The previous PR https://github.com/finn-no/BottomSheet/pull/55 fixed the index out of bounds issue, this improves a bit on that fix so that if the new `contentHeights` actually contain the current used height it will be kept.

# What?
Check if current height exists in array of new `contentHeights` and if it does set `currentTargetOffsetIndex` to the correct index for the new array.