### PR TITLE
Fix: Allow dismiss in code before presentation is complete

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,11 +2,11 @@ version: 2
 jobs:
   build-and-test:
     macos:
-      xcode: "11.2.1"
+      xcode: "13.2.0"
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout
-      - run: xcodebuild -project BottomSheet.xcodeproj -scheme "Demo" -sdk iphonesimulator -destination 'platform=iOS Simulator,OS=13.2.2,name=iPhone 11 Pro' build test | xcpretty
+      - run: xcodebuild -project BottomSheet.xcodeproj -scheme "Demo" -sdk iphonesimulator -destination 'platform=iOS Simulator,OS=15.2,name=iPhone 13 Pro' build test | xcpretty
 
   swiftlint:
     docker:

--- a/Demo/DemoViewController.swift
+++ b/Demo/DemoViewController.swift
@@ -23,22 +23,12 @@ final class DemoViewController: UIViewController {
     private func setup() {
         view.backgroundColor = .white
 
-        let buttonA = UIButton(type: .system)
-        buttonA.setTitle("Navigation View Controller", for: .normal)
-        buttonA.titleLabel?.font = .systemFont(ofSize: 18)
-        buttonA.addTarget(self, action: #selector(presentNavigationViewController), for: .touchUpInside)
-
-        let buttonB = UIButton(type: .system)
-        buttonB.setTitle("View Controller", for: .normal)
-        buttonB.titleLabel?.font = .systemFont(ofSize: 18)
-        buttonB.addTarget(self, action: #selector(presentViewController), for: .touchUpInside)
-
-        let buttonC = UIButton(type: .system)
-        buttonC.setTitle("View", for: .normal)
-        buttonC.titleLabel?.font = .systemFont(ofSize: 18)
-        buttonC.addTarget(self, action: #selector(presentView), for: .touchUpInside)
-
-        let stackView = UIStackView(arrangedSubviews: [buttonA, buttonB, buttonC])
+        let stackView = UIStackView(arrangedSubviews: [
+            createButton(title: "Navigation View Controller", selector: #selector(presentNavigationViewController)),
+            createButton(title: "View Controller", selector: #selector(presentViewController)),
+            createButton(title: "View", selector: #selector(presentView)),
+            createButton(title: "Automatic dismiss after 0.05s", selector: #selector(presentAutomaticDismiss)),
+        ])
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.axis = .vertical
 
@@ -48,6 +38,14 @@ final class DemoViewController: UIViewController {
             stackView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             stackView.centerYAnchor.constraint(equalTo: view.centerYAnchor)
         ])
+    }
+
+    private func createButton(title: String, selector: Selector) -> UIButton {
+        let button = UIButton(type: .system)
+        button.setTitle(title, for: .normal)
+        button.titleLabel?.font = .systemFont(ofSize: 18)
+        button.addTarget(self, action: selector, for: .touchUpInside)
+        return button
     }
 
     // MARK: - Presentation logic
@@ -60,6 +58,20 @@ final class DemoViewController: UIViewController {
         navigationController.navigationBar.isTranslucent = false
 
         present(navigationController, animated: true)
+    }
+
+    @objc private func presentAutomaticDismiss() {
+        let viewController = ViewController(withNavigationButton: true, contentHeight: 400)
+        viewController.title = "Step 1"
+
+        let navigationController = BottomSheetNavigationController(rootViewController: viewController)
+        navigationController.navigationBar.isTranslucent = false
+
+        present(navigationController, animated: true)
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05, execute: { [weak navigationController] in
+            navigationController?.dismiss(animated: true)
+        })
     }
 
     // MARK: - Presentation logic

--- a/Sources/BottomSheetPresentationController.swift
+++ b/Sources/BottomSheetPresentationController.swift
@@ -190,8 +190,14 @@ extension BottomSheetPresentationController: UIViewControllerAnimatedTransitioni
         self.transitionContext = transitionContext
 
         let completion = { [weak self] (didComplete: Bool) in
-            self?.transitionContext?.completeTransition(didComplete)
-            self?.transitionState = nil
+            guard let self = self else { return }
+            let previousTransitionState = self.transitionState
+
+            self.transitionContext?.completeTransition(didComplete)
+
+            if previousTransitionState == self.transitionState {
+                self.transitionState = nil
+            }
         }
 
         switch transitionState {


### PR DESCRIPTION
# Why?
We've had several issues where the BottomSheet would freeze when interacting with it, and the reason was that it was being dismissed before its presentation was complete.

The reason for this is that `BottomSheetPresentationController` sets `transitionState` to `.dismiss` when you call dismiss, which can happen before presentation is complete. However, this does not prevent the completionHandler of the animation from setting it back to `nil` after calling `UIViewControllerContextTransitioning.completeTransition(_:)`.

It seems that the dismiss is being queued up immediately after this method is called, but before the completionBlock is finished, which would place it in a frozen state.

# What?
- Make sure that the previous `transitionState` is equal to the current one before setting it to `nil`.
- Update demo.
- Update CircleCI config.

# Show me

| Before<br>(automatic dismiss, but without the fix) | After |
| --- | --- |
| ![Simulator Screen Recording - iPhone 13 Pro - 2022-03-02 at 13 40 17](https://user-images.githubusercontent.com/1901556/156363313-7f96f096-d249-446d-bbe3-db98f4f0dedd.gif) | ![Simulator Screen Recording - iPhone 13 Pro - 2022-03-02 at 13 38 41](https://user-images.githubusercontent.com/1901556/156363079-6f258f0e-15c7-4c3a-9213-0da125d03360.gif) |