### PR TITLE
Fix ambigious layout

### DIFF
--- a/Sources/BottomSheetView.swift
+++ b/Sources/BottomSheetView.swift
@@ -201,11 +201,16 @@ public final class BottomSheetView: UIView {
             self.animationDelegate?.bottomSheetView(self, didCompleteAnimation: didComplete)
         }
 
+        let bottomGreaterThanConstraint = bottomAnchor.constraint(greaterThanOrEqualTo: superview.bottomAnchor)
+        let bottomEqualConstraint = bottomAnchor.constraint(equalTo: superview.bottomAnchor)
+        bottomEqualConstraint.priority = .required - 1
+
         NSLayoutConstraint.activate([
             topConstraint,
-            bottomAnchor.constraint(greaterThanOrEqualTo: superview.bottomAnchor),
             leadingAnchor.constraint(equalTo: superview.leadingAnchor),
             trailingAnchor.constraint(equalTo: superview.trailingAnchor),
+            bottomGreaterThanConstraint,
+            bottomEqualConstraint,
             contentViewHeightConstraint
         ])
 


### PR DESCRIPTION
# Why?

There's been an ambigious layout in `BottomSheetView` for quite some time. It makes the rendering act up, especially when changing content and adjusting for the keyboard. Been looking for the issue for some time, but not been quite successful in my attempts. Finally managed to solve it I think.

# What?

* Add an additional `equalTo` constraint. 
* Set priority of `equalTo` constraint one less than `.required`

# Show me

_Hopefully no UI changes other than smoother layouts_

| Before | After |
| --- | --- |
| ![Screenshot 2022-03-24 at 09 47 34](https://user-images.githubusercontent.com/3852639/159909482-aec5e0f8-7b57-47dc-a43f-cae7751c9e34.png) | ![Screenshot 2022-03-24 at 09 48 46](https://user-images.githubusercontent.com/3852639/159909474-5c037a4a-eecc-4b46-9169-3f6fe346b5b9.png)| 
| ![Screenshot 2022-03-24 at 09 47 16](https://user-images.githubusercontent.com/3852639/159909484-6fa7c1c8-ea9a-4546-9722-b66791ccbeaf.png) | ![Screenshot 2022-03-24 at 09 46 32](https://user-images.githubusercontent.com/3852639/159909486-5c5fb7fb-3ead-446c-a6df-d98293d9f20e.png)|
