### PR TITLE
fix: Xcode 15 has broken the way we calculate the distance

### DIFF
--- a/Sources/SpringAnimator.swift
+++ b/Sources/SpringAnimator.swift
@@ -112,9 +112,9 @@ class SpringAnimator: NSObject {
 
 private extension SpringAnimator {
     @objc func step(displayLink: CADisplayLink) {
-        // Get duration in a way that supports screens with variable refresh rates 
-        let duration = displayLink.targetTimestamp - CACurrentMediaTime()
-        // Calculate new potision
+        // Get duration in a way that supports screens with variable refresh rates
+        let duration = displayLink.targetTimestamp - displayLink.timestamp
+        // Calculate new position
         position += velocity * CGFloat(duration)
         let acceleration = -velocity * damping - position * stiffness
         velocity += acceleration * CGFloat(duration)


### PR DESCRIPTION
# Why?

I don't know...but they did 😉 

# What?
Apparently, the way we calculate how much to move for each "tick" in the `CADisplayLink` is broken. 

## Currently

We calculate a `duration` (a delta time since last render) and use that to calculate how much (`position`) and how fast (`velocity`) to use. 

That duration is calculated like so:

`let duration = displayLink.targetTimestamp - CACurrentMediaTime()`

In the end of each "tick" we use this check:

`if position < scale, velocity < scale`

to determine if we should stop the animation or not.

## But
The calculation `displayLink.targetTimestamp - CACurrentMediaTime()` has changed in Xcode 15, meaning that we can now get negative values from this calculation. 

That again means that our velocity and position starts to act funny and we never end up in a positive check, meaning that our animation just continues forever.

We are not the only ones seeing this problem:

https://forums.developer.apple.com/forums/thread/762291

## The Fix
Instead of subtracting `CACurrentMediaTime` we subtract `displayLink.timestamp` which seems to give us equally values to work with. Here is a piece from the [documentation](https://developer.apple.com/documentation/quartzcore/cadisplaylink/1621292-duration) for `CADisplayLink`:

> You calculate the expected amount of time your app has to render each frame by using [targetTimestamp](https://developer.apple.com/documentation/quartzcore/cadisplaylink/1648422-targettimestamp)-[timestamp](https://developer.apple.com/documentation/quartzcore/cadisplaylink/1621257-timestamp). Use targetTimestamp-[CACurrentMediaTime()](https://developer.apple.com/documentation/quartzcore/1395996-cacurrentmediatime) to calculate the actual amount of time.

This seems to work and leaves us with similar results both in iOS 18 and pre iOS 18 so we'll go with that

# Show me

| Before | After |
| --- | --- |
|https://github.com/user-attachments/assets/4c0b57fe-06bc-43dd-9332-01b6ffc024e2 | https://github.com/user-attachments/assets/63f7606f-3047-4d96-82bc-4153c38eef7c |
